### PR TITLE
Updates to postbox

### DIFF
--- a/atomic-exec/examples/fungible-token/src/lib.rs
+++ b/atomic-exec/examples/fungible-token/src/lib.rs
@@ -163,7 +163,7 @@ impl Actor {
         let balances = balances.into_iter().try_fold(HashMap::new(), |mut m, (a, b)| -> Result<_, ActorError> {
             let id = rt
                 .resolve_address(&a)
-                .ok_or(actor_error!(illegal_argument; "cannot resolve address in initial balance table"))?
+                .ok_or_else(|| actor_error!(illegal_argument; "cannot resolve address in initial balance table"))?
                 .id()
                 .unwrap();
             m.insert(id, b);

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -14,8 +14,10 @@ keywords = ["filecoin", "web3", "wasm", "ipc"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
-primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
+#fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
+#primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
+fil_actors_runtime = { path = "../../fvm-utils/runtime", features = ["fil-actor"] }
+primitives = { path = "../../fvm-utils/primitives" }
 fvm_shared = { version = "=3.0.0-alpha.5", default-features = false }
 ipc-sdk = { path = "../sdk" }
 fvm_ipld_hamt = "0.5.1"
@@ -36,8 +38,10 @@ unsigned-varint = "0.7.1"
 
 [dev-dependencies]
 # enable test_utils feature only in dev env
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor", "test_utils"] }
+# fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", branch = "main", features = ["fil-actor", "test_utils"] }
+fil_actors_runtime = { path = "../../fvm-utils/runtime", features = ["fil-actor", "test_utils"] }
 base64 = "0.13.1"
+env_logger = "0.10.0"
 
 [build-dependencies]
 wasm-builder = "3.0.1"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -14,10 +14,8 @@ keywords = ["filecoin", "web3", "wasm", "ipc"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-#fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
-#primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
-fil_actors_runtime = { path = "../../fvm-utils/runtime", features = ["fil-actor"] }
-primitives = { path = "../../fvm-utils/primitives" }
+fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
+primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
 fvm_shared = { version = "=3.0.0-alpha.5", default-features = false }
 ipc-sdk = { path = "../sdk" }
 fvm_ipld_hamt = "0.5.1"
@@ -38,8 +36,7 @@ unsigned-varint = "0.7.1"
 
 [dev-dependencies]
 # enable test_utils feature only in dev env
-# fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", branch = "main", features = ["fil-actor", "test_utils"] }
-fil_actors_runtime = { path = "../../fvm-utils/runtime", features = ["fil-actor", "test_utils"] }
+fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor", "test_utils"] }
 base64 = "0.13.1"
 env_logger = "0.10.0"
 

--- a/gateway/src/cross.rs
+++ b/gateway/src/cross.rs
@@ -1,6 +1,5 @@
 use crate::ApplyMsgParams;
 use anyhow::anyhow;
-use cid::Cid;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::ActorError;
 use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
@@ -14,11 +13,9 @@ use fvm_shared::MethodNum;
 use fvm_shared::METHOD_SEND;
 use ipc_sdk::address::IPCAddress;
 use ipc_sdk::subnet_id::SubnetID;
-use primitives::{TAmt, TCid, TLink};
+use primitives::{TCid, TLink};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
-
-use crate::checkpoint::CrossMsgMeta;
 
 /// StorableMsg stores all the relevant information required
 /// to execute cross-messages.
@@ -149,68 +146,28 @@ pub fn is_bottomup(from: &SubnetID, to: &SubnetID) -> bool {
 
 #[derive(PartialEq, Eq, Clone, Debug, Default, Serialize, Deserialize)]
 pub struct CrossMsgs {
+    // FIXME: Consider to make this an AMT if we expect
+    // a lot of cross-messages to be propagated.
     pub msgs: Vec<CrossMsg>,
-    pub metas: Vec<CrossMsgMeta>,
 }
 impl Cbor for CrossMsgs {}
-
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
-pub struct MetaTag {
-    pub msgs_cid: TCid<TAmt<CrossMsg>>,
-    pub meta_cid: TCid<TAmt<CrossMsgMeta>>,
-}
-impl Cbor for MetaTag {}
-
-impl MetaTag {
-    pub fn new<BS: Blockstore>(store: &BS) -> anyhow::Result<MetaTag> {
-        Ok(Self {
-            msgs_cid: TCid::new_amt(store)?,
-            meta_cid: TCid::new_amt(store)?,
-        })
-    }
-}
 
 impl CrossMsgs {
     pub fn new() -> Self {
         Self::default()
     }
 
-    pub(crate) fn cid(&self) -> anyhow::Result<Cid> {
-        let store = MemoryBlockstore::new();
-        let mut meta = MetaTag::new(&store)?;
-
-        meta.msgs_cid.update(&store, |msgs_array| {
-            msgs_array
-                .batch_set(self.msgs.clone())
-                .map_err(|e| e.into())
-        })?;
-
-        meta.meta_cid.update(&store, |meta_array| {
-            meta_array
-                .batch_set(self.metas.clone())
-                .map_err(|e| e.into())
-        })?;
-
-        let meta_cid: TCid<TLink<MetaTag>> = TCid::new_link(&store, &meta)?;
-
-        Ok(meta_cid.cid())
+    pub(crate) fn cid(&self) -> anyhow::Result<TCid<TLink<CrossMsgs>>> {
+        TCid::new_link(&MemoryBlockstore::new(), &self)
     }
 
-    pub(crate) fn add_metas(&mut self, metas: Vec<CrossMsgMeta>) -> anyhow::Result<()> {
-        for m in metas.iter() {
-            if self.metas.iter().any(|ms| ms == m) {
-                continue;
-            }
-            self.metas.push(m.clone());
+    /// Appends a cross-message to cross-msgs
+    pub(crate) fn add_msg(&mut self, msg: &CrossMsg) -> bool {
+        if !self.msgs.contains(msg) {
+            self.msgs.push(msg.clone());
+            return true;
         }
-
-        Ok(())
-    }
-
-    pub(crate) fn add_msg(&mut self, msg: &CrossMsg) -> anyhow::Result<()> {
-        // TODO: Check if the message has already been added.
-        self.msgs.push(msg.clone());
-        Ok(())
+        false
     }
 }
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -729,7 +729,7 @@ impl Actor {
         })?;
 
         // it is safe to just unwrap. If `transaction` fails, cid is None and wont reach here.
-        Ok(RawBytes::new(cid.unwrap().to_bytes()))
+        Ok(RawBytes::new(cid.to_bytes()))
     }
 
     /// Whitelist a series of addresses as propagator of a cross net message.

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -714,8 +714,7 @@ impl Actor {
             }
         };
 
-        let mut cid = None;
-        rt.transaction(|st: &mut State, rt| {
+        let cid = rt.transaction(|st: &mut State, rt| {
             let owner = cross_msg
                 .msg
                 .from
@@ -726,8 +725,7 @@ impl Actor {
                 .map_err(|e| {
                     e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "error save topdown messages")
                 })?;
-            cid = Some(r);
-            Ok(())
+            Ok(r)
         })?;
 
         // it is safe to just unwrap. If `transaction` fails, cid is None and wont reach here.

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -858,6 +858,8 @@ impl Actor {
                     st.network_name
                 );
 
+                // if the message is a bottom-up message and it reached the common-parent
+                // then we need to start propagating it down to the destination.
                 let r = if nearest_common_parent == st.network_name {
                     st.commit_topdown_msg(rt.store(), &mut cross_msg)
                 } else {
@@ -867,7 +869,7 @@ impl Actor {
                 r.map_err(|e| {
                     e.downcast_default(
                         ExitCode::USR_ILLEGAL_STATE,
-                        "error committing topdown messages",
+                        "error committing bottom-up messages",
                     )
                 })?;
 

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -15,10 +15,9 @@ use lazy_static::lazy_static;
 use num_traits::Zero;
 use primitives::{TAmt, TCid, THamt, TLink};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::str::FromStr;
 
-use ipc_sdk::subnet_id::SubnetID;
+use ipc_sdk::subnet_id::{self, SubnetID};
 
 use super::checkpoint::*;
 use super::cross::*;
@@ -176,113 +175,70 @@ impl State {
         let ch_epoch = checkpoint_epoch(epoch, self.check_period);
         let checkpoints = self.checkpoints.load(store)?;
 
-        let out_ch = match get_checkpoint(&checkpoints, &ch_epoch)? {
+        Ok(match get_checkpoint(&checkpoints, &ch_epoch)? {
             Some(ch) => ch.clone(),
             None => Checkpoint::new(self.network_name.clone(), ch_epoch),
-        };
-
-        Ok(out_ch)
+        })
     }
 
-    /// apply the cross-messages included in a checkpoint.
-    pub(crate) fn apply_check_msgs<'m, BS: Blockstore>(
-        &mut self,
-        store: &'m BS,
-        sub: &mut Subnet,
-        commit: &'m Checkpoint,
-    ) -> anyhow::Result<(TokenAmount, HashMap<SubnetID, Vec<&'m CrossMsgMeta>>)> {
-        let mut burn_val = TokenAmount::zero();
-        let mut aux: HashMap<SubnetID, Vec<&CrossMsgMeta>> = HashMap::new();
-
-        // if cross-msgs directed to current network
-        for mm in commit.cross_msgs() {
-            if mm.to == self.network_name {
-                self.store_bottomup_msg(&store, mm)
-                    .map_err(|e| anyhow!("error storing bottomup msg: {}", e))?;
-            } else {
-                // if we are not the parent, someone is trying to forge messages
-                if mm.from.parent().unwrap_or_default() != self.network_name {
-                    continue;
-                }
-                let meta = aux.entry(mm.to.clone()).or_insert_with(|| vec![mm]);
-                (*meta).push(mm);
-            }
-            burn_val += &mm.value;
-            self.release_circ_supply(store, sub, &mm.from, &mm.value)?;
-        }
-
-        Ok((burn_val, aux))
-    }
-
-    /// aggregate child message meta that are not directed for the current
-    /// subnet to propagate them further.
-    pub(crate) fn agg_child_msgmeta<BS: Blockstore>(
-        &mut self,
-        store: &BS,
-        ch: &mut Checkpoint,
-        aux: HashMap<SubnetID, Vec<&CrossMsgMeta>>,
-    ) -> anyhow::Result<()> {
-        for (to, mm) in aux.into_iter() {
-            // aggregate values inside msgmeta
-            let value = mm.iter().fold(TokenAmount::zero(), |acc, x| acc + &x.value);
-            let metas = mm.into_iter().cloned().collect();
-
-            match ch.crossmsg_meta_index(&self.network_name, &to) {
-                Some(index) => {
-                    let msgmeta = &mut ch.data.cross_msgs[index];
-                    let prev_cid = &msgmeta.msgs_cid;
-                    let m_cid = self.append_metas_to_meta(store, prev_cid, metas)?;
-                    msgmeta.msgs_cid = m_cid;
-                    msgmeta.value += value;
-                }
-                None => {
-                    let mut msgmeta = CrossMsgMeta::new(&self.network_name, &to);
-                    let mut n_mt = CrossMsgs::new();
-                    n_mt.metas = metas;
-                    let meta_cid = self
-                        .check_msg_registry
-                        .modify(store, |cross_reg| put_msgmeta(cross_reg, n_mt))?;
-                    msgmeta.value += &value;
-                    msgmeta.msgs_cid = meta_cid;
-                    ch.append_msgmeta(msgmeta)?;
-                }
-            };
-        }
-
-        Ok(())
-    }
-
-    /// store a cross message in the current checkpoint for propagation
-    // TODO: We can probably de-duplicate a lot of code from agg_child_msgmeta
+    /// store a cross-message in a checkpoint
     pub(crate) fn store_msg_in_checkpoint<BS: Blockstore>(
         &mut self,
         store: &BS,
         cross_msg: &CrossMsg,
+        fee: &TokenAmount,
         curr_epoch: ChainEpoch,
     ) -> anyhow::Result<()> {
         let mut ch = self.get_window_checkpoint(store, curr_epoch)?;
 
-        let msg = &cross_msg.msg;
-        let sto = msg.to.subnet()?;
-        let sfrom = msg.from.subnet()?;
-        match ch.crossmsg_meta_index(&sfrom, &sto) {
-            Some(index) => {
-                let msgmeta = &mut ch.data.cross_msgs[index];
+        match ch.cross_msgs_mut() {
+            Some(msgmeta) => {
                 let prev_cid = &msgmeta.msgs_cid;
                 let m_cid = self.append_msg_to_meta(store, prev_cid, cross_msg)?;
                 msgmeta.msgs_cid = m_cid;
-                msgmeta.value += &msg.value;
+                msgmeta.value += &cross_msg.msg.value + fee;
+                msgmeta.fee += fee;
+            }
+            None => self.check_msg_registry.modify(store, |cross_reg| {
+                let mut msgmeta = CrossMsgMeta::default();
+                let mut crossmsgs = CrossMsgs::new();
+                let _ = crossmsgs.add_msg(cross_msg);
+                let m_cid = put_msgmeta(cross_reg, crossmsgs)?;
+                msgmeta.msgs_cid = m_cid;
+                msgmeta.value += &cross_msg.msg.value + fee;
+                msgmeta.fee += fee;
+                ch.set_cross_msgs(msgmeta);
+                Ok(())
+            })?,
+        };
+
+        // flush checkpoint
+        self.flush_checkpoint(store, &ch).map_err(|e| {
+            e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "error flushing checkpoint")
+        })?;
+
+        Ok(())
+    }
+
+    /// store a cross-fee in a checkpoint
+    pub(crate) fn store_fee_in_checkpoint<BS: Blockstore>(
+        &mut self,
+        store: &BS,
+        fee: &TokenAmount,
+        curr_epoch: ChainEpoch,
+    ) -> anyhow::Result<()> {
+        let mut ch = self.get_window_checkpoint(store, curr_epoch)?;
+
+        match ch.cross_msgs_mut() {
+            Some(msgmeta) => {
+                msgmeta.value += fee;
+                msgmeta.fee += fee;
             }
             None => {
-                let mut msgmeta = CrossMsgMeta::new(&sfrom, &sto);
-                let mut n_mt = CrossMsgs::new();
-                n_mt.msgs = vec![cross_msg.clone()];
-                let meta_cid = self
-                    .check_msg_registry
-                    .modify(store, |cross_reg| put_msgmeta(cross_reg, n_mt))?;
-                msgmeta.value += &msg.value;
-                msgmeta.msgs_cid = meta_cid;
-                ch.append_msgmeta(msgmeta)?;
+                let mut msgmeta = CrossMsgMeta::default();
+                msgmeta.value += fee;
+                msgmeta.fee += fee;
+                ch.set_cross_msgs(msgmeta);
             }
         };
 
@@ -294,33 +250,7 @@ impl State {
         Ok(())
     }
 
-    /// append crossmsg_meta to a specific mesasge meta.
-    pub(crate) fn append_metas_to_meta<BS: Blockstore>(
-        &mut self,
-        store: &BS,
-        meta_cid: &TCid<TLink<CrossMsgs>>,
-        metas: Vec<CrossMsgMeta>,
-    ) -> anyhow::Result<TCid<TLink<CrossMsgs>>> {
-        self.check_msg_registry.modify(store, |cross_reg| {
-            // get previous meta stored
-            let mut prev_meta = match cross_reg.get(&meta_cid.cid().to_bytes())? {
-                Some(m) => m.clone(),
-                None => return Err(anyhow!("no msgmeta found for cid")),
-            };
-            prev_meta.add_metas(metas)?;
-            // if the cid hasn't changed
-            let cid = TCid::from(prev_meta.cid()?);
-            if &cid == meta_cid {
-                Ok(cid)
-            } else {
-                replace_msgmeta(cross_reg, meta_cid, prev_meta)
-            }
-        })
-    }
-
-    /// append crossmsg to a specific mesasge meta.
-    // TODO: Consider de-duplicating code from append_metas_to_meta
-    // if possible
+    /// append cross-msg and/or fee reward to a specific message meta.
     pub(crate) fn append_msg_to_meta<BS: Blockstore>(
         &mut self,
         store: &BS,
@@ -329,20 +259,23 @@ impl State {
     ) -> anyhow::Result<TCid<TLink<CrossMsgs>>> {
         self.check_msg_registry.modify(store, |cross_reg| {
             // get previous meta stored
-            let mut prev_meta = match cross_reg.get(&meta_cid.cid().to_bytes())? {
+            let mut prev_crossmsgs = match cross_reg.get(&meta_cid.cid().to_bytes())? {
                 Some(m) => m.clone(),
-                None => return Err(anyhow!("no msgmeta found for cid")),
+                None => {
+                    // double-check that is not found because there were no messages
+                    // in meta and not because we messed-up something.
+                    if meta_cid.cid() != Cid::default() {
+                        return Err(anyhow!("no msgmeta found for cid"));
+                    }
+                    // return empty messages
+                    CrossMsgs::new()
+                }
             };
-
-            prev_meta.add_msg(cross_msg)?;
-
-            // if the cid hasn't changed
-            let cid = TCid::from(prev_meta.cid()?);
-            if &cid == meta_cid {
-                Ok(cid)
-            } else {
-                replace_msgmeta(cross_reg, meta_cid, prev_meta)
+            let added = prev_crossmsgs.add_msg(cross_msg);
+            if !added {
+                return Ok(meta_cid.clone());
             }
+            replace_msgmeta(cross_reg, meta_cid, prev_crossmsgs)
         })
     }
 
@@ -350,33 +283,6 @@ impl State {
     ///
     /// This is triggered through bottom-up messages sending subnet tokens
     /// to some other subnet in the hierarchy.
-    pub(crate) fn release_circ_supply<BS: Blockstore>(
-        &mut self,
-        store: &BS,
-        curr: &mut Subnet,
-        id: &SubnetID,
-        val: &TokenAmount,
-    ) -> anyhow::Result<()> {
-        // if current subnet, we don't need to get the
-        // subnet again
-        if curr.id == *id {
-            curr.release_supply(val)?;
-            return Ok(());
-        }
-
-        let sub = self
-            .get_subnet(store, id)
-            .map_err(|e| anyhow!("failed to load subnet: {}", e))?;
-        match sub {
-            Some(mut sub) => {
-                sub.release_supply(val)?;
-                self.flush_subnet(store, &sub)
-            }
-            None => return Err(anyhow!("subnet with id {} not registered", id)),
-        }?;
-        Ok(())
-    }
-
     /// store bottomup messages for their execution in the subnet
     pub(crate) fn store_bottomup_msg<BS: Blockstore>(
         &mut self,
@@ -398,10 +304,11 @@ impl State {
         &mut self,
         store: &BS,
         cross_msg: &mut CrossMsg,
+        fee: &TokenAmount,
+        curr_epoch: ChainEpoch,
     ) -> anyhow::Result<()> {
         let msg = &cross_msg.msg;
         let sto = msg.to.subnet()?;
-        // let sfrom = msg.from.subnet()?;
 
         let sub = self
             .get_subnet(
@@ -421,15 +328,19 @@ impl State {
                 sub.nonce += 1;
                 sub.circ_supply += &cross_msg.msg.value;
                 self.flush_subnet(store, &sub)?;
+
+                // store fee in checkpoint as long as we are not the root
+                // (the root should distribute the reward immediately to
+                // all validators)
+                // FIXME: Figure out how to distribute cross-fees in root.
+                if self.network_name != *subnet_id::ROOTNET_ID {
+                    self.store_fee_in_checkpoint(store, fee, curr_epoch)?;
+                }
             }
             None => {
-                if sto == self.network_name {
-                    return Err(anyhow!(
-                        "can't direct top-down message to the current subnet"
-                    ));
-                } else {
-                    self.noop_msg();
-                }
+                return Err(anyhow!(
+                    "can't direct top-down message to destination subnet"
+                ));
             }
         }
         Ok(())
@@ -440,10 +351,11 @@ impl State {
         &mut self,
         store: &BS,
         msg: &CrossMsg,
+        fee: &TokenAmount,
         curr_epoch: ChainEpoch,
     ) -> anyhow::Result<()> {
-        // store msg in checkpoint for propagation
-        self.store_msg_in_checkpoint(store, msg, curr_epoch)?;
+        // store bottom-up msg and fee in checkpoint for propagation
+        self.store_msg_in_checkpoint(store, msg, fee, curr_epoch)?;
         // increment nonce
         self.nonce += 1;
 
@@ -455,13 +367,14 @@ impl State {
         &mut self,
         store: &BS,
         cross_msg: &mut CrossMsg,
+        fee: &TokenAmount,
         curr_epoch: ChainEpoch,
     ) -> anyhow::Result<IPCMsgType> {
         let msg = &cross_msg.msg;
         let tp = msg.ipc_type()?;
         match tp {
-            IPCMsgType::TopDown => self.commit_topdown_msg(store, cross_msg)?,
-            IPCMsgType::BottomUp => self.commit_bottomup_msg(store, cross_msg, curr_epoch)?,
+            IPCMsgType::TopDown => self.commit_topdown_msg(store, cross_msg, fee, curr_epoch)?,
+            IPCMsgType::BottomUp => self.commit_bottomup_msg(store, cross_msg, fee, curr_epoch)?,
         };
         Ok(tp)
     }
@@ -487,11 +400,6 @@ impl State {
             ));
         }
         Ok(())
-    }
-
-    /// noop is triggered to notify when a crossMsg fails to be applied successfully.
-    pub fn noop_msg(&self) {
-        panic!("error committing cross-msg. noop should be returned but not implemented yet");
     }
 
     /// Insert a cross message to the `postbox` before propagate can be called for the
@@ -580,6 +488,26 @@ impl State {
             })?;
         Ok(())
     }
+
+    /// Collects cross-fee and reduces the corresponding
+    /// balances from which the fee is collected.
+    pub fn collect_cross_fee(
+        &mut self,
+        balance: &mut TokenAmount,
+        fee: &TokenAmount,
+    ) -> Result<(), ActorError> {
+        // check if the message can pay for the fees
+        if balance < &mut fee.clone() {
+            return Err(actor_error!(
+                illegal_state,
+                "not enough gas to pay cross-message"
+            ));
+        }
+
+        // update balance after collecting the fee
+        *balance -= fee;
+        Ok(())
+    }
 }
 
 pub fn set_subnet<BS: Blockstore>(
@@ -626,7 +554,7 @@ fn put_msgmeta<BS: Blockstore>(
     registry: &mut Map<BS, CrossMsgs>,
     metas: CrossMsgs,
 ) -> anyhow::Result<TCid<TLink<CrossMsgs>>> {
-    let m_cid = TCid::from(metas.cid()?);
+    let m_cid = metas.cid()?;
     registry
         .set(m_cid.cid().to_bytes().into(), metas)
         .map_err(|e| e.downcast_wrap(format!("failed to set crossmsg meta for cid {}", m_cid)))?;

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -73,8 +73,8 @@ impl State {
             nonce: Default::default(),
             bottomup_nonce: Default::default(),
             bottomup_msg_meta: TCid::new_amt(store)?,
-            // Because this way we ensure that the next one to execute is 0, if not it would expect 1 and fail for the first nonce
-            // Because we first increase to the subsequent and then execute
+            // This way we ensure that the first message to execute has nonce= 0, if not it would expect 1 and fail for the first nonce
+            // We first increase to the subsequent and then execute for bottom-up messages
             applied_bottomup_nonce: MAX_NONCE,
             applied_topdown_nonce: Default::default(),
         })

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -73,9 +73,9 @@ impl State {
             nonce: Default::default(),
             bottomup_nonce: Default::default(),
             bottomup_msg_meta: TCid::new_amt(store)?,
-            // TODO: why MAX_NONCE here?
-            // applied_bottomup_nonce: MAX_NONCE,
-            applied_bottomup_nonce: Default::default(),
+            // Because this way we ensure that the next one to execute is 0, if not it would expect 1 and fail for the first nonce
+            // Because we first increase to the subsequent and then execute
+            applied_bottomup_nonce: MAX_NONCE,
             applied_topdown_nonce: Default::default(),
         })
     }
@@ -474,8 +474,9 @@ impl State {
         // and start accepting the one for the next nonce.
         if self.applied_bottomup_nonce == u64::MAX && msg.nonce == 0 {
             self.applied_bottomup_nonce = 0;
-        } else if self.applied_bottomup_nonce + 1 == msg.nonce {
-            self.applied_bottomup_nonce += 1;
+        } else if self.applied_bottomup_nonce.wrapping_add(1) == msg.nonce {
+            // wrapping add is used to prevent overflow.
+            self.applied_bottomup_nonce = self.applied_bottomup_nonce.wrapping_add(1);
         };
 
         if self.applied_bottomup_nonce != msg.nonce {

--- a/gateway/src/types.rs
+++ b/gateway/src/types.rs
@@ -19,6 +19,8 @@ pub const DEFAULT_CHECKPOINT_PERIOD: ChainEpoch = 10;
 pub const MAX_NONCE: u64 = u64::MAX;
 pub const MIN_COLLATERAL_AMOUNT: u64 = 10_u64.pow(18);
 
+pub const SUBNET_ACTOR_REWARD_METHOD: u64 = 6;
+
 pub type CrossMsgMetaArray<'bs, BS> = Array<'bs, CrossMsgMeta, BS>;
 pub type CrossMsgArray<'bs, BS> = Array<'bs, CrossMsg, BS>;
 

--- a/gateway/src/types.rs
+++ b/gateway/src/types.rs
@@ -64,7 +64,7 @@ pub struct WhitelistPropagatorParams {
 }
 
 /// The item to store in the `State::postbox`
-#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone)]
+#[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
 pub struct PostBoxItem {
     pub cross_msg: CrossMsg,
     pub owners: Option<Vec<Address>>,

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -841,19 +841,20 @@ fn test_apply_msg_bu_switch_td() {
     let caller = ff.clone().raw_addr().unwrap();
 
     // we directly insert message into postbox as we dont really care how it's got stored in queue
-    let cid = rt.transaction(|st: &mut State, r| {
-        Ok(st
-            .insert_postbox(
-                r.store(),
-                Some(vec![caller.clone()]),
-                CrossMsg {
-                    wrapped: false,
-                    msg: params,
-                },
-            )
-            .unwrap())
-    })
-    .unwrap();
+    let cid = rt
+        .transaction(|st: &mut State, r| {
+            Ok(st
+                .insert_postbox(
+                    r.store(),
+                    Some(vec![caller.clone()]),
+                    CrossMsg {
+                        wrapped: false,
+                        msg: params,
+                    },
+                )
+                .unwrap())
+        })
+        .unwrap();
 
     let starting_nonce = get_subnet(&rt, &tt.subnet().unwrap().down(&h.net_name).unwrap())
         .unwrap()

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -681,7 +681,7 @@ fn test_send_cross() {
 }
 
 /// This test covers the case where a bottom up cross_msg's target subnet is the SAME as that of
-/// the gateway. It would directly commit the message and will not save in postbox.
+/// the gateway. It should directly commit the message and will not save in postbox.
 #[test]
 fn test_apply_msg_bu_target_subnet() {
     // ============== Register subnet ==============
@@ -733,7 +733,7 @@ fn test_apply_msg_bu_target_subnet() {
 }
 
 /// This test covers the case where a bottom up cross_msg's target subnet is NOT the same as that of
-/// the gateway. It would save in postbox.
+/// the gateway. It will save it in the postbox.
 #[test]
 fn test_apply_msg_bu_not_target_subnet() {
     // ============== Register subnet ==============

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -727,37 +727,37 @@ fn test_apply_routing() {
     h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 0, 1, ExitCode::OK, false)
         .unwrap();
 
-    let tt = IPCAddress::new(&sub2, &to).unwrap();
-    h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 1, 1, ExitCode::OK, false)
-        .unwrap();
-
-    // bottom-up
-    let ff = IPCAddress::new(&SubnetID::from_str("/root/f01/f012").unwrap(), &from).unwrap();
-    let tt = IPCAddress::new(&sub1, &to).unwrap();
-    h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 2, 2, ExitCode::OK, false)
-        .unwrap();
-    // directed to current network
-    let tt = IPCAddress::new(&shid, &to).unwrap();
-    h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 3, 0, ExitCode::OK, false)
-        .unwrap();
-
-    let ff = IPCAddress::new(&sub1, &from).unwrap();
-    let tt = IPCAddress::new(&SubnetID::from_str("/root/f0101/f0102/f011").unwrap(), &to).unwrap();
-    h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 0, 2, ExitCode::OK, false)
-        .unwrap();
-    let ff = IPCAddress::new(&sub2, &from).unwrap();
-    let tt = IPCAddress::new(&SubnetID::from_str("/root/f0101/f0101/f011").unwrap(), &to).unwrap();
-    h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 1, 3, ExitCode::OK, false)
-        .unwrap();
-    // directed to current network
-    let ff = IPCAddress::new(
-        &SubnetID::from_str("/root/f0101/f0102/f011").unwrap(),
-        &from,
-    )
-    .unwrap();
-    let tt = IPCAddress::new(&shid, &to).unwrap();
-    h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 1, 0, ExitCode::OK, false)
-        .unwrap();
+    // let tt = IPCAddress::new(&sub2, &to).unwrap();
+    // h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 1, 1, ExitCode::OK, false)
+    //     .unwrap();
+    //
+    // // bottom-up
+    // let ff = IPCAddress::new(&SubnetID::from_str("/root/f01/f012").unwrap(), &from).unwrap();
+    // let tt = IPCAddress::new(&sub1, &to).unwrap();
+    // h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 2, 2, ExitCode::OK, false)
+    //     .unwrap();
+    // // directed to current network
+    // let tt = IPCAddress::new(&shid, &to).unwrap();
+    // h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 3, 0, ExitCode::OK, false)
+    //     .unwrap();
+    //
+    // let ff = IPCAddress::new(&sub1, &from).unwrap();
+    // let tt = IPCAddress::new(&SubnetID::from_str("/root/f0101/f0102/f011").unwrap(), &to).unwrap();
+    // h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 0, 2, ExitCode::OK, false)
+    //     .unwrap();
+    // let ff = IPCAddress::new(&sub2, &from).unwrap();
+    // let tt = IPCAddress::new(&SubnetID::from_str("/root/f0101/f0101/f011").unwrap(), &to).unwrap();
+    // h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 1, 3, ExitCode::OK, false)
+    //     .unwrap();
+    // // directed to current network
+    // let ff = IPCAddress::new(
+    //     &SubnetID::from_str("/root/f0101/f0102/f011").unwrap(),
+    //     &from,
+    // )
+    // .unwrap();
+    // let tt = IPCAddress::new(&shid, &to).unwrap();
+    // h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 1, 0, ExitCode::OK, false)
+    //     .unwrap();
 }
 
 #[test]

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -35,7 +35,7 @@ fn register_subnet() {
 
     let st: State = rt.get_state();
     assert_eq!(st.total_subnets, 1);
-    let shid = SubnetID::new(&h.net_name, *SUBNET_ONE);
+    let shid = SubnetID::new_from_parent(&h.net_name, *SUBNET_ONE);
     let subnet = h.get_subnet(&rt, &shid).unwrap();
     assert_eq!(subnet.id, shid);
     assert_eq!(subnet.stake, value);
@@ -65,7 +65,7 @@ fn register_subnet() {
 
     let st: State = rt.get_state();
     assert_eq!(st.total_subnets, 2);
-    let shid = SubnetID::new(&h.net_name, *SUBNET_TWO);
+    let shid = SubnetID::new_from_parent(&h.net_name, *SUBNET_TWO);
     let subnet = h.get_subnet(&rt, &shid).unwrap();
     assert_eq!(subnet.id, shid);
     assert_eq!(subnet.stake, value);
@@ -85,7 +85,7 @@ fn add_stake() {
 
     let st: State = rt.get_state();
     assert_eq!(st.total_subnets, 1);
-    let shid = SubnetID::new(&h.net_name, *SUBNET_ONE);
+    let shid = SubnetID::new_from_parent(&h.net_name, *SUBNET_ONE);
     let subnet = h.get_subnet(&rt, &shid).unwrap();
     assert_eq!(subnet.id, shid);
     assert_eq!(subnet.stake, value);
@@ -101,7 +101,7 @@ fn add_stake() {
     // Add to unregistered subnet
     h.add_stake(
         &mut rt,
-        &SubnetID::new(&h.net_name, *SUBNET_TWO),
+        &SubnetID::new_from_parent(&h.net_name, *SUBNET_TWO),
         &value,
         ExitCode::USR_ILLEGAL_ARGUMENT,
     )
@@ -133,7 +133,7 @@ fn release_stake() {
 
     let st: State = rt.get_state();
     assert_eq!(st.total_subnets, 1);
-    let shid = SubnetID::new(&h.net_name, *SUBNET_ONE);
+    let shid = SubnetID::new_from_parent(&h.net_name, *SUBNET_ONE);
     let subnet = h.get_subnet(&rt, &shid).unwrap();
     assert_eq!(subnet.id, shid);
     assert_eq!(subnet.stake, value);
@@ -156,7 +156,7 @@ fn release_stake() {
     // Release from unregistered subnet
     h.release_stake(
         &mut rt,
-        &SubnetID::new(&h.net_name, *SUBNET_TWO),
+        &SubnetID::new_from_parent(&h.net_name, *SUBNET_TWO),
         &value,
         ExitCode::USR_ILLEGAL_ARGUMENT,
     )
@@ -211,7 +211,7 @@ fn test_kill() {
 
     let st: State = rt.get_state();
     assert_eq!(st.total_subnets, 1);
-    let shid = SubnetID::new(&h.net_name, *SUBNET_ONE);
+    let shid = SubnetID::new_from_parent(&h.net_name, *SUBNET_ONE);
     let subnet = h.get_subnet(&rt, &shid).unwrap();
     assert_eq!(subnet.id, shid);
     assert_eq!(subnet.stake, value);
@@ -237,7 +237,7 @@ fn checkpoint_commit() {
 
     let st: State = rt.get_state();
     assert_eq!(st.total_subnets, 1);
-    let shid = SubnetID::new(&h.net_name, *SUBNET_ONE);
+    let shid = SubnetID::new_from_parent(&h.net_name, *SUBNET_ONE);
     let subnet = h.get_subnet(&rt, &shid).unwrap();
     assert_eq!(subnet.id, shid);
     assert_eq!(subnet.stake, value);
@@ -288,7 +288,7 @@ fn checkpoint_commit() {
 
     let st: State = rt.get_state();
     assert_eq!(st.total_subnets, 2);
-    let shid_two = SubnetID::new(&h.net_name, *SUBNET_TWO);
+    let shid_two = SubnetID::new_from_parent(&h.net_name, *SUBNET_TWO);
     let subnet = h.get_subnet(&rt, &shid_two).unwrap();
     assert_eq!(subnet.id, shid_two);
     h.check_state();
@@ -330,7 +330,7 @@ fn checkpoint_crossmsgs() {
 
     let st: State = rt.get_state();
     assert_eq!(st.total_subnets, 1);
-    let shid = SubnetID::new(&h.net_name, *SUBNET_ONE);
+    let shid = SubnetID::new_from_parent(&h.net_name, *SUBNET_ONE);
     let subnet = h.get_subnet(&rt, &shid).unwrap();
     assert_eq!(subnet.id, shid);
     assert_eq!(subnet.stake, value);
@@ -383,7 +383,7 @@ fn checkpoint_crossmsgs() {
     add_msg_meta(
         &mut ch,
         &shid,
-        &SubnetID::new(&h.net_name, Address::new_id(100)),
+        &SubnetID::new_from_parent(&h.net_name, Address::new_id(100)),
         "rand1".as_bytes().to_vec(),
         TokenAmount::zero(),
     );
@@ -482,7 +482,7 @@ fn test_fund() {
 
     let st: State = rt.get_state();
     assert_eq!(st.total_subnets, 1);
-    let shid = SubnetID::new(&h.net_name, *SUBNET_ONE);
+    let shid = SubnetID::new_from_parent(&h.net_name, *SUBNET_ONE);
     let subnet = h.get_subnet(&rt, &shid).unwrap();
     assert_eq!(subnet.id, shid);
     assert_eq!(subnet.stake, value);
@@ -541,7 +541,7 @@ fn test_fund() {
     h.fund(
         &mut rt,
         &funder,
-        &SubnetID::new(&h.net_name, *SUBNET_TWO),
+        &SubnetID::new_from_parent(&h.net_name, *SUBNET_TWO),
         ExitCode::USR_ILLEGAL_ARGUMENT,
         TokenAmount::zero(),
         3,
@@ -552,7 +552,7 @@ fn test_fund() {
 
 #[test]
 fn test_release() {
-    let shid = SubnetID::new(&ROOTNET_ID, *SUBNET_ONE);
+    let shid = SubnetID::new_from_parent(&ROOTNET_ID, *SUBNET_ONE);
     let (h, mut rt) = setup(shid.clone());
 
     let releaser = Address::new_id(1001);
@@ -575,7 +575,7 @@ fn test_release() {
 
 #[test]
 fn test_send_cross() {
-    let shid = SubnetID::new(&ROOTNET_ID, *SUBNET_ONE);
+    let shid = SubnetID::new_from_parent(&ROOTNET_ID, *SUBNET_ONE);
     let (h, mut rt) = setup(shid.clone());
 
     let from = Address::new_id(1001);
@@ -677,14 +677,17 @@ fn test_send_cross() {
 
 #[test]
 fn test_apply_routing() {
-    let shid = SubnetID::new(&ROOTNET_ID, *SUBNET_ONE);
+    env_logger::init();
+
+    // let shid = SubnetID::new_from_parent(&ROOTNET_ID, *SUBNET_ONE);
+    let shid = ROOTNET_ID.clone();
     let (h, mut rt) = setup(shid.clone());
 
     let from = Address::new_bls(&[3; fvm_shared::address::BLS_PUB_LEN]).unwrap();
     let to = Address::new_bls(&[4; fvm_shared::address::BLS_PUB_LEN]).unwrap();
 
-    let sub1 = SubnetID::new(&shid, *SUBNET_ONE);
-    let sub2 = SubnetID::new(&shid, *SUBNET_TWO);
+    let sub1 = SubnetID::new_from_parent(&shid, *SUBNET_ONE);
+    let sub2 = SubnetID::new_from_parent(&shid, *SUBNET_TWO);
 
     // register subnets
     let reg_value = TokenAmount::from_atto(10_u64.pow(18));
@@ -723,9 +726,12 @@ fn test_apply_routing() {
     let tt = IPCAddress::new(&sub1, &to).unwrap();
     h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 0, 1, ExitCode::OK, false)
         .unwrap();
+
     let tt = IPCAddress::new(&sub2, &to).unwrap();
     h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 1, 1, ExitCode::OK, false)
         .unwrap();
+
+    // bottom-up
     let ff = IPCAddress::new(&SubnetID::from_str("/root/f01/f012").unwrap(), &from).unwrap();
     let tt = IPCAddress::new(&sub1, &to).unwrap();
     h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 2, 2, ExitCode::OK, false)
@@ -735,7 +741,6 @@ fn test_apply_routing() {
     h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 3, 0, ExitCode::OK, false)
         .unwrap();
 
-    // bottom-up
     let ff = IPCAddress::new(&sub1, &from).unwrap();
     let tt = IPCAddress::new(&SubnetID::from_str("/root/f0101/f0102/f011").unwrap(), &to).unwrap();
     h.apply_cross_msg(&mut rt, &ff, &tt, value.clone(), 0, 2, ExitCode::OK, false)
@@ -756,14 +761,14 @@ fn test_apply_routing() {
 }
 
 #[test]
-fn test_apply_msg() {
+fn test_apply_msg_match_target_subnet() {
     let (h, mut rt) = setup_root();
 
     // Register a subnet with 1FIL collateral
     let value = TokenAmount::from_atto(10_u64.pow(18));
     h.register(&mut rt, &SUBNET_ONE, &value, ExitCode::OK)
         .unwrap();
-    let shid = SubnetID::new(&h.net_name, *SUBNET_ONE);
+    let shid = SubnetID::new_from_parent(&h.net_name, *SUBNET_ONE);
 
     // inject some funds
     let funder_id = Address::new_id(1001);

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -800,7 +800,6 @@ fn test_apply_msg_bu_not_target_subnet() {
 /// top down cross msg should occur.
 #[test]
 fn test_apply_msg_bu_switch_td() {
-    env_logger::init();
     // ============== Register subnet ==============
     let parent_sub = SubnetID::new_from_parent(&ROOTNET_ID, *SUBNET_ONE);
     let (h, mut rt) = setup(parent_sub.clone());

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -11,7 +11,7 @@ use fil_actors_runtime::test_utils::{
 };
 use fil_actors_runtime::{
     make_map_with_root_and_bitwidth, ActorError, Map, BURNT_FUNDS_ACTOR_ADDR, REWARD_ACTOR_ADDR,
-    STORAGE_POWER_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
+    SYSTEM_ACTOR_ADDR,
 };
 use fil_actors_runtime::{Array, INIT_ACTOR_ADDR};
 use fvm_ipld_blockstore::Blockstore;
@@ -27,8 +27,8 @@ use ipc_gateway::checkpoint::ChildCheck;
 use ipc_gateway::{
     ext, get_topdown_msg, is_bottomup, Actor, ApplyMsgParams, Checkpoint, ConstructorParams,
     CrossMsg, CrossMsgMeta, CrossMsgParams, CrossMsgs, FundParams, IPCAddress, IPCMsgType, Method,
-    PropagateParams, State, StorableMsg, Subnet, SubnetID, CROSSMSG_AMT_BITWIDTH,
-    DEFAULT_CHECKPOINT_PERIOD, MAX_NONCE, MIN_COLLATERAL_AMOUNT, MIN_CROSS_MSG_GAS, SCA_ACTOR_ADDR,
+    PropagateParams, State, StorableMsg, Subnet, SubnetID, CROSSMSG_AMT_BITWIDTH, CROSS_MSG_FEE,
+    DEFAULT_CHECKPOINT_PERIOD, MAX_NONCE, MIN_COLLATERAL_AMOUNT,
 };
 use lazy_static::lazy_static;
 use primitives::{TCid, TCidContent};
@@ -43,12 +43,12 @@ lazy_static! {
     pub static ref TEST_BLS: Address =
         Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();
     pub static ref ACTOR: Address = Address::new_actor("actor".as_bytes());
-    pub static ref TYPES: Vec<Cid> = vec![*ACCOUNT_ACTOR_CODE_ID, *MULTISIG_ACTOR_CODE_ID];
+    pub static ref SIG_TYPES: Vec<Cid> = vec![*ACCOUNT_ACTOR_CODE_ID, *MULTISIG_ACTOR_CODE_ID];
 }
 
 pub fn new_runtime() -> MockRuntime {
     MockRuntime {
-        receiver: *STORAGE_POWER_ACTOR_ADDR,
+        receiver: *ACTOR,
         caller: *SYSTEM_ACTOR_ADDR,
         caller_type: *SYSTEM_ACTOR_CODE_ID,
         ..Default::default()
@@ -251,7 +251,6 @@ impl Harness {
         id: &SubnetID,
         ch: &Checkpoint,
         code: ExitCode,
-        burn_value: TokenAmount,
     ) -> Result<(), ActorError> {
         rt.set_caller(*SUBNET_ACTOR_CODE_ID, id.subnet_actor());
         rt.expect_validate_caller_any();
@@ -266,17 +265,6 @@ impl Harness {
             );
             rt.verify();
             return Ok(());
-        }
-
-        if burn_value > TokenAmount::zero() {
-            rt.expect_send(
-                *BURNT_FUNDS_ACTOR_ADDR,
-                METHOD_SEND,
-                RawBytes::default(),
-                burn_value.clone(),
-                RawBytes::default(),
-                ExitCode::OK,
-            );
         }
         rt.call::<Actor>(
             Method::CommitChildCheckpoint as MethodNum,
@@ -299,9 +287,11 @@ impl Harness {
         expected_circ_sup: &TokenAmount,
     ) -> Result<(), ActorError> {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *funder);
-        rt.expect_validate_caller_type(TYPES.clone());
+        rt.expect_validate_caller_type(SIG_TYPES.clone());
 
-        rt.set_value(value.clone());
+        // set value and include the cross_msg_fee
+        set_rt_value_with_cross_fee(rt, &value);
+
         if code != ExitCode::OK {
             expect_abort(
                 code,
@@ -354,11 +344,13 @@ impl Harness {
         value: TokenAmount,
         expected_nonce: u64,
         prev_meta: &Cid,
+        expected_fee: TokenAmount,
     ) -> Result<Cid, ActorError> {
         rt.set_caller(*ACCOUNT_ACTOR_CODE_ID, *releaser);
-        rt.expect_validate_caller_type(TYPES.clone());
+        rt.expect_validate_caller_type(SIG_TYPES.clone());
+        // set value and include the cross_msg_fee
+        set_rt_value_with_cross_fee(rt, &value);
 
-        rt.set_value(value.clone());
         if code != ExitCode::OK {
             expect_abort(
                 code,
@@ -395,8 +387,9 @@ impl Harness {
         let to = IPCAddress::new(&parent, &TEST_BLS).unwrap();
         rt.set_epoch(0);
         let ch = st.get_window_checkpoint(rt.store(), 0).unwrap();
-        let chmeta_ind = ch.crossmsg_meta_index(&self.net_name, &parent).unwrap();
-        let chmeta = &ch.data.cross_msgs[chmeta_ind];
+        let chmeta = ch.cross_msgs().unwrap();
+        // check that fees are collected
+        assert_eq!(chmeta.fee, expected_fee);
 
         let cross_reg = st.check_msg_registry.load(rt.store()).unwrap();
         let meta = get_cross_msgs(&cross_reg, &chmeta.msgs_cid.cid())
@@ -433,9 +426,10 @@ impl Harness {
         expected_circ_sup: &TokenAmount,
     ) -> Result<(), ActorError> {
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, *SYSTEM_ACTOR_ADDR);
-        rt.expect_validate_caller_not_type(TYPES.clone());
+        rt.expect_validate_caller_not_type(SIG_TYPES.clone());
 
-        rt.set_value(value.clone());
+        // set value and include the cross_msg_fee
+        set_rt_value_with_cross_fee(rt, &value);
 
         let msg = StorableMsg {
             from: IPCAddress::new(source_sub, from).unwrap(),
@@ -443,7 +437,7 @@ impl Harness {
             nonce,
             method: METHOD_SEND,
             params: RawBytes::default(),
-            value: value.clone(),
+            value: value.clone() + &*CROSS_MSG_FEE,
         };
         let dest = sub.clone();
         let cross = CrossMsg {
@@ -490,11 +484,10 @@ impl Harness {
             let to = IPCAddress::new(&dest, &to).unwrap();
             rt.set_epoch(0);
             let ch = st.get_window_checkpoint(rt.store(), 0).unwrap();
-            let chmeta_ind = ch.crossmsg_meta_index(&self.net_name, &dest).unwrap();
-            let chmeta = &ch.data.cross_msgs[chmeta_ind];
+            let chmeta = ch.cross_msgs();
 
             let cross_reg = st.check_msg_registry.load(rt.store()).unwrap();
-            let meta = get_cross_msgs(&cross_reg, &chmeta.msgs_cid.cid())
+            let meta = get_cross_msgs(&cross_reg, &chmeta.unwrap().msgs_cid.cid())
                 .unwrap()
                 .unwrap();
             let msg = meta.msgs[nonce as usize].clone();
@@ -561,11 +554,24 @@ impl Harness {
         rt: &mut MockRuntime,
         owner: Address,
         cid: Cid,
+        msg_value: &TokenAmount,
+        excess: TokenAmount,
     ) -> Result<(), ActorError> {
         rt.set_caller(Default::default(), owner);
         rt.expect_validate_caller_any();
-        rt.set_balance(MIN_CROSS_MSG_GAS.clone());
-        rt.set_received(MIN_CROSS_MSG_GAS.clone());
+        rt.set_balance(msg_value.clone() + CROSS_MSG_FEE.clone() + excess.clone());
+        rt.set_received(CROSS_MSG_FEE.clone() + excess.clone());
+
+        if excess > TokenAmount::zero() {
+            rt.expect_send(
+                owner,
+                METHOD_SEND,
+                RawBytes::default(),
+                excess.clone(),
+                RawBytes::default(),
+                ExitCode::OK,
+            );
+        }
 
         rt.call::<Actor>(
             Method::Propagate as MethodNum,
@@ -585,7 +591,6 @@ impl Harness {
         msg_nonce: u64,
         td_nonce: u64,
         code: ExitCode,
-        noop: bool,
     ) -> Result<(), ActorError> {
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, *SYSTEM_ACTOR_ADDR);
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR.clone()]);
@@ -650,7 +655,7 @@ impl Harness {
             assert_eq!(st.applied_bottomup_nonce, msg_nonce);
         } else {
             let rew_params = ext::reward::FundingParams {
-                addr: *SCA_ACTOR_ADDR,
+                addr: *ACTOR,
                 value: params.value.clone(),
             };
             rt.expect_send(
@@ -706,10 +711,6 @@ impl Harness {
                 assert_eq!(st.applied_topdown_nonce, msg_nonce + 1);
             }
         }
-
-        if noop {
-            panic!("TODO: Not implemented yet");
-        }
         Ok(())
     }
 
@@ -746,28 +747,6 @@ pub fn has_cid<'a, T: TCidContent>(children: &'a Vec<TCid<T>>, cid: &Cid) -> boo
     children.iter().any(|c| c.cid() == *cid)
 }
 
-pub fn add_msg_meta(
-    ch: &mut Checkpoint,
-    from: &SubnetID,
-    to: &SubnetID,
-    rand: Vec<u8>,
-    value: TokenAmount,
-) {
-    let mh_code = Code::Blake2b256;
-    let c = TCid::from(Cid::new_v1(
-        fvm_ipld_encoding::DAG_CBOR,
-        mh_code.digest(&rand),
-    ));
-    let meta = CrossMsgMeta {
-        from: from.clone(),
-        to: to.clone(),
-        msgs_cid: c,
-        nonce: 0,
-        value,
-    };
-    ch.append_msgmeta(meta).unwrap();
-}
-
 pub fn get_cross_msgs<'m, BS: Blockstore>(
     registry: &'m Map<BS, CrossMsgs>,
     cid: &Cid,
@@ -775,4 +754,27 @@ pub fn get_cross_msgs<'m, BS: Blockstore>(
     registry
         .get(&cid.to_bytes())
         .map_err(|e| anyhow!("error getting fross messages: {:?}", e))
+}
+
+fn set_rt_value_with_cross_fee(rt: &mut MockRuntime, value: &TokenAmount) {
+    rt.set_value(if value.clone() != TokenAmount::zero() {
+        value.clone() + &*CROSS_MSG_FEE
+    } else {
+        value.clone()
+    });
+}
+
+pub fn set_msg_meta(ch: &mut Checkpoint, rand: Vec<u8>, value: TokenAmount, fee: TokenAmount) {
+    let mh_code = Code::Blake2b256;
+    let c = TCid::from(Cid::new_v1(
+        fvm_ipld_encoding::DAG_CBOR,
+        mh_code.digest(&rand),
+    ));
+    let meta = CrossMsgMeta {
+        msgs_cid: c,
+        nonce: 0,
+        value,
+        fee,
+    };
+    ch.set_cross_msgs(meta);
 }

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -39,6 +39,7 @@ lazy_static! {
         SubnetID::new_from_parent(&SubnetID::from_str("/root").unwrap(), Address::new_id(0));
     pub static ref SUBNET_ONE: Address = Address::new_id(101);
     pub static ref SUBNET_TWO: Address = Address::new_id(102);
+    pub static ref SUBNET_THR: Address = Address::new_id(103);
     pub static ref TEST_BLS: Address =
         Address::new_bls(&[1; fvm_shared::address::BLS_PUB_LEN]).unwrap();
     pub static ref ACTOR: Address = Address::new_actor("actor".as_bytes());
@@ -645,8 +646,8 @@ impl Harness {
                 .unwrap(),
             )?;
             rt.verify();
-            let st: State = rt.get_state();
-            assert_eq!(st.applied_bottomup_nonce, msg_nonce);
+            // let st: State = rt.get_state();
+            // assert_eq!(st.applied_bottomup_nonce, msg_nonce);
         } else {
             let rew_params = ext::reward::FundingParams {
                 addr: *SCA_ACTOR_ADDR,

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -646,8 +646,8 @@ impl Harness {
                 .unwrap(),
             )?;
             rt.verify();
-            // let st: State = rt.get_state();
-            // assert_eq!(st.applied_bottomup_nonce, msg_nonce);
+            let st: State = rt.get_state();
+            assert_eq!(st.applied_bottomup_nonce, msg_nonce);
         } else {
             let rew_params = ext::reward::FundingParams {
                 addr: *SCA_ACTOR_ADDR,

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -8,6 +8,14 @@ use std::str::FromStr;
 
 const IPC_SEPARATOR_ADDR: &str = ":";
 
+// TODO: We should specify the definition of `IPCAddress` with more detailed definition.
+// TODO: For example, IPCAddress, does it include the Gateways' addresses? Or just the subnet
+// TODO: addresses?
+// TODO: Are all the subnets under one Gateway would have the same parent gateway? Also the same
+// TODO: parent subnet?
+// TODO: Also, we need to distinguish between `IPCAddress` and `SubnetID`, what are there differences?
+// TODO: In the Constructor, there is a `network_name`, what is `network_name` to be exact?
+// TODO: Does the ROOTNET have a gateway?
 #[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 pub struct IPCAddress {
     subnet_id: SubnetID,
@@ -77,7 +85,7 @@ mod tests {
     #[test]
     fn test_ipc_address() {
         let act = Address::new_id(1001);
-        let sub_id = SubnetID::new(&ROOTNET_ID.clone(), act);
+        let sub_id = SubnetID::new_from_parent(&ROOTNET_ID.clone(), act);
         let bls = Address::from_str("f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a").unwrap();
         let haddr = IPCAddress::new(&sub_id, &bls).unwrap();
 
@@ -91,7 +99,7 @@ mod tests {
 
     #[test]
     fn test_ipc_from_str() {
-        let sub_id = SubnetID::new(&ROOTNET_ID.clone(), Address::new_id(100));
+        let sub_id = SubnetID::new_from_parent(&ROOTNET_ID.clone(), Address::new_id(100));
         let addr = IPCAddress::new(&sub_id, &Address::new_id(101)).unwrap();
         let st = addr.to_string().unwrap();
         let addr_out = IPCAddress::from_str(&st).unwrap();
@@ -100,7 +108,7 @@ mod tests {
 
     #[test]
     fn test_ipc_serialization() {
-        let sub_id = SubnetID::new(&ROOTNET_ID.clone(), Address::new_id(100));
+        let sub_id = SubnetID::new_from_parent(&ROOTNET_ID.clone(), Address::new_id(100));
         let addr = IPCAddress::new(&sub_id, &Address::new_id(101)).unwrap();
         let st = addr.to_bytes().unwrap();
         let addr_out = IPCAddress::from_bytes(&st).unwrap();

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -8,14 +8,6 @@ use std::str::FromStr;
 
 const IPC_SEPARATOR_ADDR: &str = ":";
 
-// TODO: We should specify the definition of `IPCAddress` with more detailed definition.
-// TODO: For example, IPCAddress, does it include the Gateways' addresses? Or just the subnet
-// TODO: addresses?
-// TODO: Are all the subnets under one Gateway would have the same parent gateway? Also the same
-// TODO: parent subnet?
-// TODO: Also, we need to distinguish between `IPCAddress` and `SubnetID`, what are there differences?
-// TODO: In the Constructor, there is a `network_name`, what is `network_name` to be exact?
-// TODO: Does the ROOTNET have a gateway?
 #[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 pub struct IPCAddress {
     subnet_id: SubnetID,

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -8,96 +8,17 @@ use std::str::FromStr;
 
 use crate::error::Error;
 
-/// ```
-/// // TODO: Consider new proposal, maybe? This would address the kind of awkward representation
-/// // TODO: of `ROOTNET_ID`.
-/// // TODO: Another limitation of current representation is all subnets must live under one FVM network,
-/// // TODO: do we want to scale this?
-/// //
-/// // =============== PROPOSAL 1 ===============
-/// use fvm_shared::address::Address;
-///
-/// struct SubnetInner {
-///     parent: String,
-///     actor: Address
-/// }
-/// pub struct SubnetId {
-///     inner: Option<SubnetInner>
-/// }
-///
-/// ROOT = SubnetId { inner: None };
-/// ```
-/// ```
-/// // TODO: The problem with proposal 1, also this is another confusion from existing design is,
-/// // TODO: there is no way to tell which gateway a subnet belongs to.
-/// //
-/// // =============== PROPOSAL 2 ===============
-/// use fvm_shared::address::Address;
-/// use lazy_static::lazy_static;
-///
-/// struct SubnetInner {
-///     parent: String,
-///     gateway: Address,
-///     actor: Address,
-/// }
-///
-/// #[derive(Clone)]
-/// pub enum SubnetId {
-///     Gateway { parent: String, actor: Address },
-///     Subnet (Option<SubnetInner>),
-/// }
-///
-/// lazy_static! {
-///     pub static ref ROOTNET_ID: SubnetId = SubnetId::Subnet(None);
-/// }
-///
-/// impl SubnetId {
-///     fn parent(&self) -> Option<SubnetId> { todo!() }
-///
-///     fn gateway(&self) -> Option<SubnetId> {
-///         match self {
-///             Gateway { .. } => Some(self.clone()),
-///             Subnet(s) => match s {
-///                 None => None,
-///                 Some(SubnetInner { parent, gateway, .. }) => Some(Self::Gateway { parent, actor: gateway })
-///             }
-///         }
-///     }
-///
-///     fn to_string(&self) -> String {
-///         match self {
-///             Gateway { parent, actor } => {
-///                 format!("{}/g:{}", parent, actor.to_string())
-///             }
-///             Subnet(s) => match s {
-///                 None => String::from("/root"),
-///                 Some(SubnetInner { parent, gateway, actor }) => {
-///                     format!("{}/g:{}/s:{}", parent, gateway.to_string(), actor.to_string())
-///                 }
-///             }
-///         }
-///     }
-/// }
-/// ```
 #[derive(PartialEq, Eq, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct SubnetID {
-    // TODO: The current naming seems a bit confusing. It really should be called like `subnet_path`
-    // TODO: instead of `parent`.
     parent: String,
-    /// TODO: maybe change this to Option<Address> since ROOTNET_ID should have no actor address
     actor: Address,
 }
-//                                                  network_name: /root/subnet_actor1 => SubnetId{ "/root", actor: "subnet_actor1" }
-//      gateway -> subnet_actor1            ->             gateway  ->  subnet_actor3  = SubnetId { parent: "/root/subnet_actor1", actor: "subnet_actor3" }
-//              -> subnet_actor2
-// subnet
-// network: vec![subnet]
 impl Cbor for SubnetID {}
 
 
 lazy_static! {
     pub static ref ROOTNET_ID: SubnetID = SubnetID {
-        parent: String::from("/root"), // TODO: /root is not the parent, it's the name
+        parent: String::from("/root"),
         actor: Address::new_id(0)
     };
     pub static ref UNDEF: SubnetID = SubnetID {

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -15,7 +15,6 @@ pub struct SubnetID {
 }
 impl Cbor for SubnetID {}
 
-
 lazy_static! {
     pub static ref ROOTNET_ID: SubnetID = SubnetID {
         parent: String::from("/root"),

--- a/subnet-actor/src/lib.rs
+++ b/subnet-actor/src/lib.rs
@@ -10,8 +10,9 @@ use fvm_ipld_encoding::RawBytes;
 
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
-use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
+use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND};
 use ipc_gateway::{Checkpoint, FundParams, MIN_COLLATERAL_AMOUNT};
+use num::BigInt;
 use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Zero};
 
@@ -29,6 +30,7 @@ pub enum Method {
     Leave = 3,
     Kill = 4,
     SubmitCheckpoint = 5,
+    Reward = 6,
 }
 
 /// SubnetActor trait. Custom subnet actors need to implement this trait
@@ -61,6 +63,12 @@ pub trait SubnetActor {
         rt: &mut RT,
         ch: Checkpoint,
     ) -> Result<Option<RawBytes>, ActorError>
+    where
+        BS: Blockstore,
+        RT: Runtime<BS>;
+
+    /// Distributes the rewards for the subnet to validators.
+    fn reward<BS, RT>(rt: &mut RT) -> Result<Option<RawBytes>, ActorError>
     where
         BS: Blockstore,
         RT: Runtime<BS>;
@@ -144,7 +152,7 @@ impl SubnetActor for Actor {
 
             st.mutate_state();
 
-            Ok(true)
+            Ok(())
         })?;
 
         if let Some(p) = msg {
@@ -199,7 +207,7 @@ impl SubnetActor for Actor {
 
             st.mutate_state();
 
-            Ok(true)
+            Ok(())
         })?;
 
         if let Some(p) = msg {
@@ -252,7 +260,7 @@ impl SubnetActor for Actor {
                 TokenAmount::zero(),
             ));
 
-            Ok(true)
+            Ok(())
         })?;
 
         // unregister subnet
@@ -338,7 +346,7 @@ impl SubnetActor for Actor {
                 st.set_votes(rt.store(), &ch_cid, votes)?;
             }
 
-            Ok(true)
+            Ok(())
         })?;
 
         // propagate to sca
@@ -346,6 +354,45 @@ impl SubnetActor for Actor {
             rt.send(p.to, p.method, p.params, p.value)?;
         }
 
+        Ok(None)
+    }
+
+    /// Distributes the rewards for the subnet to validators.
+    fn reward<BS, RT>(rt: &mut RT) -> Result<Option<RawBytes>, ActorError>
+    where
+        BS: Blockstore,
+        RT: Runtime<BS>,
+    {
+        let st: State = rt.state()?;
+        // the ipc-gateway must trigger the reward distribution
+        rt.validate_immediate_caller_is(vec![&st.ipc_gateway_addr])?;
+
+        let amount = rt.message().value_received();
+        if amount == TokenAmount::zero() {
+            return Err(actor_error!(
+                illegal_argument,
+                "no rewards sent for distribution"
+            ));
+        };
+
+        // even distribution of rewards. Each subnet may choose more
+        // complex and fair policies to incentivize certain behaviors.
+        // we may even have a default one for IPC.
+        let div = {
+            if st.validator_set.len() == 0 {
+                return Err(actor_error!(illegal_state, "no validators in subnet"));
+            };
+            match BigInt::from_usize(st.validator_set.len()) {
+                None => {
+                    return Err(actor_error!(illegal_state, "couldn't convert into BigInt"));
+                }
+                Some(val) => val,
+            }
+        };
+        let rew_amount = amount.div_floor(div);
+        for v in st.validator_set.into_iter() {
+            rt.send(v.addr, METHOD_SEND, RawBytes::default(), rew_amount.clone())?;
+        }
         Ok(None)
     }
 }
@@ -379,6 +426,10 @@ impl ActorCode for Actor {
             }
             Some(Method::SubmitCheckpoint) => {
                 let res = Self::submit_checkpoint(rt, cbor::deserialize_params(params)?)?;
+                Ok(RawBytes::serialize(res)?)
+            }
+            Some(Method::Reward) => {
+                let res = Self::reward(rt)?;
                 Ok(RawBytes::serialize(res)?)
             }
             None => Err(actor_error!(unhandled_message; "Invalid method")),

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -30,6 +30,8 @@ lazy_static! {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct State {
     pub name: String,
+    /// The parent id of the subnet actor, it should be the same as the
+    /// actor's gateway's state.network_name
     pub parent_id: SubnetID,
     pub ipc_gateway_addr: Address,
     pub consensus: ConsensusType,

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -308,7 +308,7 @@ impl State {
         }
 
         // check the source is correct
-        if *ch.source() != SubnetID::new(&self.parent_id, rt.message().receiver()) {
+        if *ch.source() != SubnetID::new_from_parent(&self.parent_id, rt.message().receiver()) {
             return Err(anyhow!("submitting checkpoint with the wrong source"));
         }
 

--- a/subnet-actor/tests/actor_test.rs
+++ b/subnet-actor/tests/actor_test.rs
@@ -488,7 +488,7 @@ mod test {
 
         // Generate the check point
         let root_subnet = SubnetID::from_str("/root").unwrap();
-        let subnet = SubnetID::new(&root_subnet, test_actor_address);
+        let subnet = SubnetID::new_from_parent(&root_subnet, test_actor_address);
         let epoch = 10;
         let mut checkpoint_0 = Checkpoint::new(subnet.clone(), epoch);
         checkpoint_0.set_signature(

--- a/subnet-actor/tests/actor_test.rs
+++ b/subnet-actor/tests/actor_test.rs
@@ -9,10 +9,13 @@ mod test {
     use fvm_shared::crypto::signature::Signature;
     use fvm_shared::econ::TokenAmount;
     use fvm_shared::error::ExitCode;
+    use fvm_shared::METHOD_SEND;
     use ipc_gateway::{Checkpoint, FundParams, SubnetID, MIN_COLLATERAL_AMOUNT};
     use ipc_subnet_actor::{
         Actor, ConsensusType, ConstructParams, JoinParams, Method, State, Status,
     };
+    use num::BigInt;
+    use num_traits::FromPrimitive;
     use num_traits::Zero;
     use primitives::TCid;
     use std::str::FromStr;
@@ -95,6 +98,7 @@ mod test {
 
         let caller = Address::new_id(10);
         let validator = Address::new_id(100);
+        let gateway = Address::new_id(IPC_GATEWAY_ADDR);
         let start_token_value = 5_u64.pow(18);
         let params = JoinParams {
             validator_net_addr: validator.to_string(),
@@ -114,6 +118,15 @@ mod test {
             )
             .unwrap();
 
+        // reward fails because there is no validators.
+        runtime.set_value(value.clone());
+        runtime.set_caller(Cid::default(), gateway.clone());
+        runtime.expect_validate_caller_addr(vec![gateway.clone()]);
+        expect_abort(
+            ExitCode::USR_ILLEGAL_STATE,
+            runtime.call::<Actor>(Method::Reward as u64, &RawBytes::default()),
+        );
+
         // verify state.
         // as the value is less than min collateral, state is initiated
         let st: State = runtime.get_state();
@@ -130,7 +143,7 @@ mod test {
         runtime.set_balance(TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT));
         runtime.expect_validate_caller_any();
         runtime.expect_send(
-            Address::new_id(IPC_GATEWAY_ADDR),
+            gateway.clone(),
             ipc_gateway::Method::Register as u64,
             RawBytes::default(),
             TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT),
@@ -168,7 +181,7 @@ mod test {
         runtime.set_balance(TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT));
         runtime.expect_validate_caller_any();
         runtime.expect_send(
-            Address::new_id(IPC_GATEWAY_ADDR),
+            gateway.clone(),
             ipc_gateway::Method::AddStake as u64,
             RawBytes::default(),
             TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT),
@@ -196,6 +209,39 @@ mod test {
             stake.unwrap(),
             TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT)
         );
+        runtime.verify();
+
+        // reward is fairly distribute among all validators,
+        // and fails if no tokens are sent.
+        runtime.set_value(TokenAmount::zero());
+        runtime.set_caller(Cid::default(), gateway.clone());
+        runtime.expect_validate_caller_addr(vec![gateway.clone()]);
+        expect_abort(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            runtime.call::<Actor>(Method::Reward as u64, &RawBytes::default()),
+        );
+
+        let total_reward = TokenAmount::from_atto(2);
+        runtime.set_value(total_reward.clone());
+        runtime.set_caller(Cid::default(), gateway.clone());
+        runtime.expect_validate_caller_addr(vec![gateway.clone()]);
+        runtime.set_balance(TokenAmount::from_atto(3));
+        let st: State = runtime.get_state();
+        let rew_amount =
+            total_reward.div_floor(BigInt::from_usize(st.validator_set.len()).unwrap());
+        for v in st.validator_set.into_iter() {
+            runtime.expect_send(
+                v.addr,
+                METHOD_SEND,
+                RawBytes::default(),
+                rew_amount.clone(),
+                RawBytes::default(),
+                ExitCode::new(0),
+            );
+        }
+        runtime
+            .call::<Actor>(Method::Reward as u64, &RawBytes::default())
+            .unwrap();
         runtime.verify();
     }
 


### PR DESCRIPTION
## Changes

This is a separate PR to `wrapped_msg` as we have quite some number of changes, so that we can track what's updated from the previous agreed upon version.
The changes are:

- `commit_cross_msg` for bottom up adding switch to top down message 
- gateway's state applied_bottomup_nonce use wrapping_add
- removed test case `test_apply_routing` with 5 more tests: `test_apply_msg_bu_target_subnet`, `test_apply_msg_bu_not_target_subnet`, `test_apply_msg_bu_switch_td`, `test_apply_msg_tp_target_subnet`, `test_apply_msg_tp_not_target_subnet`, please review them carefully. Fixed all other broken tests.
- `apply_msg` restricted to only `SYSTEM_ACTOR_ADDR`.
- `insert_postbox` returns the just inserted `Cid`

If ok, then we merge this PR to `wrapped_msg` then merge `wrapped_msg` to `main`.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo test --all
```

