### PR TITLE
Charging and distributing cross-msg fees

### DIFF
--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -64,39 +64,14 @@ impl Checkpoint {
         &self.data.prev_check
     }
 
-    /// return cross_msg metas included in the checkpoint.
-    pub fn cross_msgs(&self) -> &Vec<CrossMsgMeta> {
+    /// return cross_msg included in the checkpoint.
+    pub fn cross_msgs(&self) -> &CrossMsgMeta {
         &self.data.cross_msgs
     }
 
-    /// return specific crossmsg meta from and to the corresponding subnets.
-    pub fn crossmsg_meta(&self, from: &SubnetID, to: &SubnetID) -> Option<&CrossMsgMeta> {
-        self.data
-            .cross_msgs
-            .iter()
-            .find(|m| from == &m.from && to == &m.to)
-    }
-
-    /// return the index in crossmsg_meta of the structure including metadata from
-    /// and to the correponding subnets.
-    pub fn crossmsg_meta_index(&self, from: &SubnetID, to: &SubnetID) -> Option<usize> {
-        self.data
-            .cross_msgs
-            .iter()
-            .position(|m| from == &m.from && to == &m.to)
-    }
-
-    /// append msgmeta to checkpoint
-    pub fn append_msgmeta(&mut self, meta: CrossMsgMeta) -> anyhow::Result<()> {
-        match self.crossmsg_meta(&meta.from, &meta.to) {
-            Some(mm) => {
-                if meta != *mm {
-                    self.data.cross_msgs.push(meta)
-                }
-            }
-            None => self.data.cross_msgs.push(meta),
-        }
-        Ok(())
+    /// return cross_msg included in the checkpoint as mutable reference
+    pub fn cross_msgs_mut(&mut self) -> &mut CrossMsgMeta {
+        &mut self.data.cross_msgs
     }
 
     /// Add the cid of a checkpoint from a child subnet for further propagation
@@ -141,7 +116,7 @@ pub struct CheckData {
     pub epoch: ChainEpoch,
     pub prev_check: TCid<TLink<Checkpoint>>,
     pub children: Vec<ChildCheck>,
-    pub cross_msgs: Vec<CrossMsgMeta>,
+    pub cross_msgs: CrossMsgMeta,
 }
 impl CheckData {
     pub fn new(id: SubnetID, epoch: ChainEpoch) -> Self {
@@ -151,16 +126,16 @@ impl CheckData {
             epoch,
             prev_check: TCid::default(),
             children: Vec::new(),
-            cross_msgs: Vec::new(),
+            cross_msgs: CrossMsgMeta::default(),
         }
     }
 }
 impl Cbor for CheckData {}
 
+// CrossMsgMeta sends an aggregate of all messages being propagated up in
+// the checkpoint.
 #[derive(PartialEq, Eq, Clone, Debug, Default, Serialize, Deserialize)]
 pub struct CrossMsgMeta {
-    pub from: SubnetID,
-    pub to: SubnetID,
     pub msgs_cid: TCid<TLink<CrossMsgs>>,
     pub nonce: u64,
     pub value: TokenAmount,
@@ -168,12 +143,8 @@ pub struct CrossMsgMeta {
 impl Cbor for CrossMsgMeta {}
 
 impl CrossMsgMeta {
-    pub fn new(from: &SubnetID, to: &SubnetID) -> Self {
-        Self {
-            from: from.clone(),
-            to: to.clone(),
-            ..Default::default()
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn set_nonce(&mut self, nonce: u64) {

--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -144,6 +144,7 @@ pub struct CrossMsgMeta {
     pub msgs_cid: TCid<TLink<CrossMsgs>>,
     pub nonce: u64,
     pub value: TokenAmount,
+    pub fee: TokenAmount,
 }
 impl Cbor for CrossMsgMeta {}
 

--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -65,13 +65,18 @@ impl Checkpoint {
     }
 
     /// return cross_msg included in the checkpoint.
-    pub fn cross_msgs(&self) -> &CrossMsgMeta {
-        &self.data.cross_msgs
+    pub fn cross_msgs(&self) -> Option<&CrossMsgMeta> {
+        self.data.cross_msgs.as_ref()
+    }
+
+    /// set cross_msg included in the checkpoint.
+    pub fn set_cross_msgs(&mut self, cm: CrossMsgMeta) {
+        self.data.cross_msgs = Some(cm)
     }
 
     /// return cross_msg included in the checkpoint as mutable reference
-    pub fn cross_msgs_mut(&mut self) -> &mut CrossMsgMeta {
-        &mut self.data.cross_msgs
+    pub fn cross_msgs_mut(&mut self) -> Option<&mut CrossMsgMeta> {
+        self.data.cross_msgs.as_mut()
     }
 
     /// Add the cid of a checkpoint from a child subnet for further propagation
@@ -116,7 +121,7 @@ pub struct CheckData {
     pub epoch: ChainEpoch,
     pub prev_check: TCid<TLink<Checkpoint>>,
     pub children: Vec<ChildCheck>,
-    pub cross_msgs: CrossMsgMeta,
+    pub cross_msgs: Option<CrossMsgMeta>,
 }
 impl CheckData {
     pub fn new(id: SubnetID, epoch: ChainEpoch) -> Self {
@@ -126,7 +131,7 @@ impl CheckData {
             epoch,
             prev_check: TCid::default(),
             children: Vec::new(),
-            cross_msgs: CrossMsgMeta::default(),
+            cross_msgs: None,
         }
     }
 }

--- a/gateway/src/cross.rs
+++ b/gateway/src/cross.rs
@@ -3,7 +3,6 @@ use anyhow::anyhow;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::ActorError;
 use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
-use fil_actors_runtime::REWARD_ACTOR_ADDR;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::Cbor;
@@ -115,29 +114,6 @@ impl StorableMsg {
         })
     }
 
-    pub fn new_reward_msg(
-        curr_sub: &SubnetID,
-        value: TokenAmount,
-        nonce: u64,
-    ) -> anyhow::Result<Self> {
-        let to = IPCAddress::new(
-            &match curr_sub.parent() {
-                Some(s) => s,
-                None => return Err(anyhow!("error getting parent for subnet addr")),
-            },
-            &curr_sub.subnet_actor(),
-        )?;
-        let from = IPCAddress::new(curr_sub, &REWARD_ACTOR_ADDR)?;
-        Ok(Self {
-            from,
-            to,
-            method: METHOD_SEND,
-            params: RawBytes::default(),
-            value,
-            nonce,
-        })
-    }
-
     pub fn ipc_type(&self) -> anyhow::Result<IPCMsgType> {
         let sto = self.to.subnet()?;
         let sfrom = self.from.subnet()?;
@@ -186,12 +162,12 @@ impl CrossMsgs {
     }
 
     /// Appends a cross-message to cross-msgs
-    pub(crate) fn add_msg(&mut self, msg: &CrossMsg) -> anyhow::Result<bool> {
+    pub(crate) fn add_msg(&mut self, msg: &CrossMsg) -> bool {
         if !self.msgs.contains(msg) {
             self.msgs.push(msg.clone());
-            return Ok(true);
+            return true;
         }
-        Ok(false)
+        false
     }
 }
 

--- a/gateway/src/cross.rs
+++ b/gateway/src/cross.rs
@@ -1,6 +1,5 @@
 use crate::ApplyMsgParams;
 use anyhow::anyhow;
-use cid::Cid;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::ActorError;
 use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
@@ -14,11 +13,9 @@ use fvm_shared::MethodNum;
 use fvm_shared::METHOD_SEND;
 use ipc_sdk::address::IPCAddress;
 use ipc_sdk::subnet_id::SubnetID;
-use primitives::{TAmt, TCid, TLink};
+use primitives::{TCid, TLink};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
-
-use crate::checkpoint::CrossMsgMeta;
 
 /// StorableMsg stores all the relevant information required
 /// to execute cross-messages.
@@ -149,68 +146,28 @@ pub fn is_bottomup(from: &SubnetID, to: &SubnetID) -> bool {
 
 #[derive(PartialEq, Eq, Clone, Debug, Default, Serialize, Deserialize)]
 pub struct CrossMsgs {
+    // FIXME: Consider to make this an AMT if we expect
+    // a lot of cross-messages to be propagated.
     pub msgs: Vec<CrossMsg>,
-    pub metas: Vec<CrossMsgMeta>,
 }
 impl Cbor for CrossMsgs {}
-
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
-pub struct MetaTag {
-    pub msgs_cid: TCid<TAmt<CrossMsg>>,
-    pub meta_cid: TCid<TAmt<CrossMsgMeta>>,
-}
-impl Cbor for MetaTag {}
-
-impl MetaTag {
-    pub fn new<BS: Blockstore>(store: &BS) -> anyhow::Result<MetaTag> {
-        Ok(Self {
-            msgs_cid: TCid::new_amt(store)?,
-            meta_cid: TCid::new_amt(store)?,
-        })
-    }
-}
 
 impl CrossMsgs {
     pub fn new() -> Self {
         Self::default()
     }
 
-    pub(crate) fn cid(&self) -> anyhow::Result<Cid> {
-        let store = MemoryBlockstore::new();
-        let mut meta = MetaTag::new(&store)?;
-
-        meta.msgs_cid.update(&store, |msgs_array| {
-            msgs_array
-                .batch_set(self.msgs.clone())
-                .map_err(|e| e.into())
-        })?;
-
-        meta.meta_cid.update(&store, |meta_array| {
-            meta_array
-                .batch_set(self.metas.clone())
-                .map_err(|e| e.into())
-        })?;
-
-        let meta_cid: TCid<TLink<MetaTag>> = TCid::new_link(&store, &meta)?;
-
-        Ok(meta_cid.cid())
+    pub(crate) fn cid(&self) -> anyhow::Result<TCid<TLink<CrossMsgs>>> {
+        TCid::new_link(&MemoryBlockstore::new(), &self)
     }
 
-    pub(crate) fn add_metas(&mut self, metas: Vec<CrossMsgMeta>) -> anyhow::Result<()> {
-        for m in metas.iter() {
-            if self.metas.iter().any(|ms| ms == m) {
-                continue;
-            }
-            self.metas.push(m.clone());
+    pub(crate) fn add_msg(&mut self, msg: &CrossMsg) -> anyhow::Result<bool> {
+        // FIXME: Consider a more efficient impl.
+        if !self.msgs.contains(msg) {
+            self.msgs.push(msg.clone());
+            return Ok(true);
         }
-
-        Ok(())
-    }
-
-    pub(crate) fn add_msg(&mut self, msg: &CrossMsg) -> anyhow::Result<()> {
-        // TODO: Check if the message has already been added.
-        self.msgs.push(msg.clone());
-        Ok(())
+        Ok(false)
     }
 }
 

--- a/gateway/src/cross.rs
+++ b/gateway/src/cross.rs
@@ -14,6 +14,7 @@ use fvm_shared::MethodNum;
 use fvm_shared::METHOD_SEND;
 use ipc_sdk::address::IPCAddress;
 use ipc_sdk::subnet_id::SubnetID;
+use num_traits::Zero;
 use primitives::{TCid, TLink};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -173,6 +174,7 @@ pub struct CrossMsgs {
     // FIXME: Consider to make this an AMT if we expect
     // a lot of cross-messages to be propagated.
     pub msgs: Vec<CrossMsg>,
+    pub fee: TokenAmount,
 }
 impl Cbor for CrossMsgs {}
 
@@ -185,13 +187,31 @@ impl CrossMsgs {
         TCid::new_link(&MemoryBlockstore::new(), &self)
     }
 
-    pub(crate) fn add_msg(&mut self, msg: &CrossMsg) -> anyhow::Result<bool> {
-        // FIXME: Consider a more efficient impl.
-        if !self.msgs.contains(msg) {
-            self.msgs.push(msg.clone());
-            return Ok(true);
+    /// Appends a cross-message and/or a fee to CrossMsg and
+    /// returns the total value being appended to the checkpoint.
+    pub(crate) fn add_msg_and_fee(
+        &mut self,
+        msg: Option<&CrossMsg>,
+        fee: &TokenAmount,
+    ) -> anyhow::Result<TokenAmount> {
+        if msg.is_none() && fee == &TokenAmount::zero() {
+            return Ok(TokenAmount::zero());
         }
-        Ok(false)
+
+        // add message
+        let mut value = TokenAmount::zero();
+        if msg.is_some() {
+            let msg = msg.unwrap();
+            if !self.msgs.contains(msg) {
+                self.msgs.push(msg.clone());
+                value += &msg.msg.value;
+            }
+        }
+
+        // add fee
+        self.fee += fee;
+        value += fee;
+        Ok(value)
     }
 }
 

--- a/gateway/src/cross.rs
+++ b/gateway/src/cross.rs
@@ -3,6 +3,7 @@ use anyhow::anyhow;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::ActorError;
 use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
+use fil_actors_runtime::REWARD_ACTOR_ADDR;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::Cbor;
@@ -111,6 +112,29 @@ impl StorableMsg {
             params: RawBytes::default(),
             value,
             nonce: 0,
+        })
+    }
+
+    pub fn new_reward_msg(
+        curr_sub: &SubnetID,
+        value: TokenAmount,
+        nonce: u64,
+    ) -> anyhow::Result<Self> {
+        let to = IPCAddress::new(
+            &match curr_sub.parent() {
+                Some(s) => s,
+                None => return Err(anyhow!("error getting parent for subnet addr")),
+            },
+            &curr_sub.subnet_actor(),
+        )?;
+        let from = IPCAddress::new(curr_sub, &REWARD_ACTOR_ADDR)?;
+        Ok(Self {
+            from,
+            to,
+            method: METHOD_SEND,
+            params: RawBytes::default(),
+            value,
+            nonce,
         })
     }
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -500,7 +500,7 @@ impl Actor {
 
         let sig_addr = resolve_secp_bls(rt, rt.message().caller())?;
 
-        let out_val = rt.transaction(|st: &mut State, rt| -> Result<TokenAmount, ActorError> {
+        rt.transaction(|st: &mut State, rt| {
             // collect fees
             st.collect_cross_fee(&mut value, &*MIN_CROSS_MSG_GAS)?;
 
@@ -529,7 +529,7 @@ impl Actor {
                         "error committing top-down message",
                     )
                 })?;
-            Ok(value)
+            Ok(())
         })?;
 
         // burn funds that are being released
@@ -537,7 +537,7 @@ impl Actor {
             *BURNT_FUNDS_ACTOR_ADDR,
             METHOD_SEND,
             RawBytes::default(),
-            out_val,
+            value,
         )?;
 
         Ok(())

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -202,7 +202,7 @@ impl State {
             None => self.check_msg_registry.modify(store, |cross_reg| {
                 let mut msgmeta = CrossMsgMeta::default();
                 let mut crossmsgs = CrossMsgs::new();
-                let _ = crossmsgs.add_msg(cross_msg)?;
+                let _ = crossmsgs.add_msg(cross_msg);
                 let m_cid = put_msgmeta(cross_reg, crossmsgs)?;
                 msgmeta.msgs_cid = m_cid;
                 msgmeta.value += &cross_msg.msg.value + fee;
@@ -271,7 +271,7 @@ impl State {
                     CrossMsgs::new()
                 }
             };
-            let added = prev_crossmsgs.add_msg(cross_msg)?;
+            let added = prev_crossmsgs.add_msg(cross_msg);
             if !added {
                 return Ok(meta_cid.clone());
             }

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -271,7 +271,6 @@ impl State {
     ) -> anyhow::Result<()> {
         let msg = &cross_msg.msg;
         let sto = msg.to.subnet()?;
-        // let sfrom = msg.from.subnet()?;
 
         let sub = self
             .get_subnet(
@@ -470,20 +469,6 @@ impl State {
         self.gov_acc += fee;
         *balance -= fee;
         Ok(())
-    }
-
-    pub fn distribute_cross_fees<BS: Blockstore>(
-        &mut self,
-        amount: TokenAmount,
-    ) -> anyhow::Result<()> {
-        // TODO: Distribution of cross fees among validators.
-        // This may not be straightforward, it may require
-        // sending the funds from the government account up
-        // (where the information of the validator set exists),
-        // and then distribute it there with the commitment of the
-        // checkpoint.
-        panic!("not implemented")
-        // Ok(())
     }
 }
 

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -262,7 +262,7 @@ impl State {
             let mut prev_crossmsgs = match cross_reg.get(&meta_cid.cid().to_bytes())? {
                 Some(m) => m.clone(),
                 None => {
-                    // double-check that is not find because there were no messages
+                    // double-check that is not found because there were no messages
                     // in meta and not because we messed-up something.
                     if meta_cid.cid() != Cid::default() {
                         return Err(anyhow!("no msgmeta found for cid"));
@@ -332,6 +332,7 @@ impl State {
                 // store fee in checkpoint as long as we are not the root
                 // (the root should distribute the reward immediately to
                 // all validators)
+                // FIXME: Figure out how to distribute cross-fees in root.
                 if self.network_name != *subnet_id::ROOTNET_ID {
                     self.store_fee_in_checkpoint(store, fee, curr_epoch)?;
                 }

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -179,12 +179,10 @@ impl State {
         let ch_epoch = checkpoint_epoch(epoch, self.check_period);
         let checkpoints = self.checkpoints.load(store)?;
 
-        let out_ch = match get_checkpoint(&checkpoints, &ch_epoch)? {
+        Ok(match get_checkpoint(&checkpoints, &ch_epoch)? {
             Some(ch) => ch.clone(),
             None => Checkpoint::new(self.network_name.clone(), ch_epoch),
-        };
-
-        Ok(out_ch)
+        })
     }
 
     /// store a cross message in the current checkpoint for propagation

--- a/gateway/src/types.rs
+++ b/gateway/src/types.rs
@@ -19,6 +19,8 @@ pub const DEFAULT_CHECKPOINT_PERIOD: ChainEpoch = 10;
 pub const MAX_NONCE: u64 = u64::MAX;
 pub const MIN_COLLATERAL_AMOUNT: u64 = 10_u64.pow(18);
 
+pub const SUBNET_ACTOR_REWARD_METHOD: u64 = 6;
+
 pub type CrossMsgMetaArray<'bs, BS> = Array<'bs, CrossMsgMeta, BS>;
 pub type CrossMsgArray<'bs, BS> = Array<'bs, CrossMsg, BS>;
 

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -11,7 +11,7 @@ use fvm_shared::METHOD_SEND;
 use ipc_gateway::Status::{Active, Inactive};
 use ipc_gateway::{
     ext, get_bottomup_msg, get_topdown_msg, Checkpoint, CrossMsg, IPCAddress, State, StorableMsg,
-    DEFAULT_CHECKPOINT_PERIOD,
+    CROSS_MSG_FEE, DEFAULT_CHECKPOINT_PERIOD,
 };
 use ipc_sdk::subnet_id::SubnetID;
 use primitives::TCid;
@@ -553,6 +553,9 @@ fn test_fund() {
         &exp_cs,
     )
     .unwrap();
+    let st: State = rt.get_state();
+    // check that fees are collected successfully
+    assert_eq!(st.gov_acc, 3 * &*CROSS_MSG_FEE);
 }
 
 #[test]
@@ -576,6 +579,10 @@ fn test_release() {
         .unwrap();
     h.release(&mut rt, &releaser, ExitCode::OK, r_amount, 1, &prev_cid)
         .unwrap();
+
+    let st: State = rt.get_state();
+    // check that fees are collected successfully
+    assert_eq!(st.gov_acc, 2 * &*CROSS_MSG_FEE);
 }
 
 #[test]

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -11,7 +11,7 @@ use fvm_shared::METHOD_SEND;
 use ipc_gateway::Status::{Active, Inactive};
 use ipc_gateway::{
     ext, get_bottomup_msg, get_topdown_msg, Checkpoint, CrossMsg, IPCAddress, State, StorableMsg,
-    DEFAULT_CHECKPOINT_PERIOD, MIN_CROSS_MSG_GAS, SCA_ACTOR_ADDR,
+    DEFAULT_CHECKPOINT_PERIOD,
 };
 use ipc_sdk::subnet_id::SubnetID;
 use primitives::TCid;
@@ -502,8 +502,7 @@ fn test_fund() {
         &funder,
         &shid,
         ExitCode::OK,
-        // TODO: Make the fee an argument
-        amount.clone() + &*MIN_CROSS_MSG_GAS,
+        amount.clone(),
         1,
         &amount,
     )
@@ -515,7 +514,7 @@ fn test_fund() {
         &funder,
         &shid,
         ExitCode::OK,
-        amount.clone() + &*MIN_CROSS_MSG_GAS,
+        amount.clone(),
         2,
         &exp_cs,
     )
@@ -526,7 +525,7 @@ fn test_fund() {
         &funder,
         &shid,
         ExitCode::OK,
-        amount.clone() + &*MIN_CROSS_MSG_GAS,
+        amount.clone(),
         3,
         &exp_cs,
     )
@@ -929,7 +928,7 @@ fn test_apply_msg_tp_target_subnet() {
                     *REWARD_ACTOR_ADDR,
                     ext::reward::EXTERNAL_FUNDING_METHOD,
                     RawBytes::serialize(ext::reward::FundingParams {
-                        addr: *SCA_ACTOR_ADDR,
+                        addr: *ACTOR,
                         value: v.clone(),
                     })
                     .unwrap(),
@@ -1012,7 +1011,7 @@ fn test_apply_msg_tp_not_target_subnet() {
                     *REWARD_ACTOR_ADDR,
                     ext::reward::EXTERNAL_FUNDING_METHOD,
                     RawBytes::serialize(ext::reward::FundingParams {
-                        addr: *SCA_ACTOR_ADDR,
+                        addr: *ACTOR,
                         value: v.clone(),
                     })
                     .unwrap(),

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -11,7 +11,7 @@ use fvm_shared::METHOD_SEND;
 use ipc_gateway::Status::{Active, Inactive};
 use ipc_gateway::{
     ext, get_bottomup_msg, get_topdown_msg, Checkpoint, CrossMsg, IPCAddress, State, StorableMsg,
-    DEFAULT_CHECKPOINT_PERIOD, SCA_ACTOR_ADDR,
+    DEFAULT_CHECKPOINT_PERIOD, MIN_CROSS_MSG_GAS, SCA_ACTOR_ADDR,
 };
 use ipc_sdk::subnet_id::SubnetID;
 use primitives::TCid;
@@ -502,7 +502,8 @@ fn test_fund() {
         &funder,
         &shid,
         ExitCode::OK,
-        amount.clone(),
+        // TODO: Make the fee an argument
+        amount.clone() + &*MIN_CROSS_MSG_GAS,
         1,
         &amount,
     )
@@ -514,7 +515,7 @@ fn test_fund() {
         &funder,
         &shid,
         ExitCode::OK,
-        amount.clone(),
+        amount.clone() + &*MIN_CROSS_MSG_GAS,
         2,
         &exp_cs,
     )
@@ -525,7 +526,7 @@ fn test_fund() {
         &funder,
         &shid,
         ExitCode::OK,
-        amount.clone(),
+        amount.clone() + &*MIN_CROSS_MSG_GAS,
         3,
         &exp_cs,
     )

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -440,9 +440,6 @@ fn test_fund() {
         &exp_cs,
     )
     .unwrap();
-    let st: State = rt.get_state();
-    // check that fees are collected successfully
-    assert_eq!(st.gov_acc, 3 * &*CROSS_MSG_FEE);
 }
 
 #[test]
@@ -466,10 +463,6 @@ fn test_release() {
         .unwrap();
     h.release(&mut rt, &releaser, ExitCode::OK, r_amount, 1, &prev_cid)
         .unwrap();
-
-    let st: State = rt.get_state();
-    // check that fees are collected successfully
-    assert_eq!(st.gov_acc, 2 * &*CROSS_MSG_FEE);
 }
 
 #[test]
@@ -1102,47 +1095,20 @@ fn test_apply_msg_match_target_subnet() {
 
     // Apply fund messages
     for i in 0..5 {
-        h.apply_cross_msg(
-            &mut rt,
-            &funder,
-            &funder,
-            value.clone(),
-            i,
-            i,
-            ExitCode::OK,
-            false,
-        )
-        .unwrap();
+        h.apply_cross_msg(&mut rt, &funder, &funder, value.clone(), i, i, ExitCode::OK)
+            .unwrap();
     }
     // Apply release messages
     let from = IPCAddress::new(&shid, &BURNT_FUNDS_ACTOR_ADDR).unwrap();
     // with the same nonce
     for _ in 0..5 {
-        h.apply_cross_msg(
-            &mut rt,
-            &from,
-            &funder,
-            value.clone(),
-            0,
-            0,
-            ExitCode::OK,
-            false,
-        )
-        .unwrap();
+        h.apply_cross_msg(&mut rt, &from, &funder, value.clone(), 0, 0, ExitCode::OK)
+            .unwrap();
     }
     // with increasing nonce
     for i in 0..5 {
-        h.apply_cross_msg(
-            &mut rt,
-            &from,
-            &funder,
-            value.clone(),
-            i,
-            i,
-            ExitCode::OK,
-            false,
-        )
-        .unwrap();
+        h.apply_cross_msg(&mut rt, &from, &funder, value.clone(), i, i, ExitCode::OK)
+            .unwrap();
     }
 
     // trying to apply non-subsequent nonce.
@@ -1154,7 +1120,6 @@ fn test_apply_msg_match_target_subnet() {
         10,
         0,
         ExitCode::USR_ILLEGAL_STATE,
-        false,
     )
     .unwrap();
     // trying already applied nonce
@@ -1166,7 +1131,6 @@ fn test_apply_msg_match_target_subnet() {
         0,
         0,
         ExitCode::USR_ILLEGAL_STATE,
-        false,
     )
     .unwrap();
 

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -1240,8 +1240,3 @@ fn test_apply_msg_match_target_subnet() {
 
     // TODO: Trying to release over circulating supply
 }
-
-#[test]
-fn test_noop() {
-    // TODO: Implement tests of what happens if the application
-}

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -10,8 +10,8 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::METHOD_SEND;
 use ipc_gateway::Status::{Active, Inactive};
 use ipc_gateway::{
-    ext, get_topdown_msg, Checkpoint, CrossMsg, IPCAddress, State, StorableMsg,
-    CROSSMSG_AMT_BITWIDTH, CROSS_MSG_FEE, DEFAULT_CHECKPOINT_PERIOD, SUBNET_ACTOR_REWARD_METHOD,
+    ext, get_topdown_msg, Checkpoint, CrossMsg, IPCAddress, State, StorableMsg, CROSS_MSG_FEE,
+    DEFAULT_CHECKPOINT_PERIOD, SUBNET_ACTOR_REWARD_METHOD,
 };
 use ipc_sdk::subnet_id::SubnetID;
 use primitives::TCid;

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -776,3 +776,17 @@ fn set_rt_value_with_cross_fee(rt: &mut MockRuntime, value: &TokenAmount) {
         value.clone()
     });
 }
+
+pub fn set_msg_meta(ch: &mut Checkpoint, rand: Vec<u8>, value: TokenAmount) {
+    let mh_code = Code::Blake2b256;
+    let c = TCid::from(Cid::new_v1(
+        fvm_ipld_encoding::DAG_CBOR,
+        mh_code.digest(&rand),
+    ));
+    let meta = CrossMsgMeta {
+        msgs_cid: c,
+        nonce: 0,
+        value,
+    };
+    ch.data.cross_msgs = meta;
+}

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -437,7 +437,8 @@ impl Harness {
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, *SYSTEM_ACTOR_ADDR);
         rt.expect_validate_caller_not_type(SIG_TYPES.clone());
 
-        rt.set_value(value.clone());
+        // set value and include the cross_msg_fee
+        set_rt_value_with_cross_fee(rt, &value);
 
         let msg = StorableMsg {
             from: IPCAddress::new(source_sub, from).unwrap(),
@@ -599,7 +600,6 @@ impl Harness {
         msg_nonce: u64,
         td_nonce: u64,
         code: ExitCode,
-        noop: bool,
     ) -> Result<(), ActorError> {
         rt.set_caller(*SYSTEM_ACTOR_CODE_ID, *SYSTEM_ACTOR_ADDR);
         rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR.clone()]);
@@ -719,10 +719,6 @@ impl Harness {
             } else {
                 assert_eq!(st.applied_topdown_nonce, msg_nonce + 1);
             }
-        }
-
-        if noop {
-            panic!("TODO: Not implemented yet");
         }
         Ok(())
     }

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -401,7 +401,7 @@ impl Harness {
         let chmeta = ch.cross_msgs();
 
         let cross_reg = st.check_msg_registry.load(rt.store()).unwrap();
-        let meta = get_cross_msgs(&cross_reg, &chmeta.msgs_cid.cid())
+        let meta = get_cross_msgs(&cross_reg, &chmeta.unwrap().msgs_cid.cid())
             .unwrap()
             .unwrap();
         let msg = meta.msgs[expected_nonce as usize].clone();
@@ -419,7 +419,7 @@ impl Harness {
             }
         }
 
-        Ok(chmeta.msgs_cid.cid())
+        Ok(chmeta.unwrap().msgs_cid.cid())
     }
 
     pub fn send_cross(
@@ -495,7 +495,7 @@ impl Harness {
             let chmeta = ch.cross_msgs();
 
             let cross_reg = st.check_msg_registry.load(rt.store()).unwrap();
-            let meta = get_cross_msgs(&cross_reg, &chmeta.msgs_cid.cid())
+            let meta = get_cross_msgs(&cross_reg, &chmeta.unwrap().msgs_cid.cid())
                 .unwrap()
                 .unwrap();
             let msg = meta.msgs[nonce as usize].clone();
@@ -788,5 +788,5 @@ pub fn set_msg_meta(ch: &mut Checkpoint, rand: Vec<u8>, value: TokenAmount) {
         nonce: 0,
         value,
     };
-    ch.data.cross_msgs = meta;
+    ch.set_cross_msgs(meta);
 }

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -564,11 +564,23 @@ impl Harness {
         rt: &mut MockRuntime,
         owner: Address,
         cid: Cid,
+        excess: TokenAmount,
     ) -> Result<(), ActorError> {
         rt.set_caller(Default::default(), owner);
         rt.expect_validate_caller_any();
-        rt.set_balance(CROSS_MSG_FEE.clone());
-        rt.set_received(CROSS_MSG_FEE.clone());
+        rt.set_balance(CROSS_MSG_FEE.clone() + excess.clone());
+        rt.set_received(CROSS_MSG_FEE.clone() + excess.clone());
+
+        if excess > TokenAmount::zero() {
+            rt.expect_send(
+                owner,
+                METHOD_SEND,
+                RawBytes::default(),
+                excess.clone(),
+                RawBytes::default(),
+                ExitCode::OK,
+            );
+        }
 
         rt.call::<Actor>(
             Method::Propagate as MethodNum,

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -341,7 +341,8 @@ impl Harness {
         assert_eq!(msg.from, from);
         assert_eq!(msg.to, to);
         assert_eq!(msg.nonce, expected_nonce - 1);
-        assert_eq!(msg.value, value);
+        // TODO: Make the cross-msg fee configurable in tests.
+        assert_eq!(msg.value, value - &*MIN_CROSS_MSG_GAS);
 
         Ok(())
     }

--- a/subnet-actor/src/lib.rs
+++ b/subnet-actor/src/lib.rs
@@ -378,7 +378,6 @@ impl SubnetActor for Actor {
         // even distribution of rewards. Each subnet may choose more
         // complex and fair policies to incentivize certain behaviors.
         // we may even have a default one for IPC.
-        // let rew_amount = amount.div_floor(TokenAmount::from(st.validator_set.len().into()));
         let div = {
             if st.validator_set.len() == 0 {
                 return Err(actor_error!(illegal_state, "no validators in subnet"));

--- a/subnet-actor/tests/actor_test.rs
+++ b/subnet-actor/tests/actor_test.rs
@@ -9,10 +9,13 @@ mod test {
     use fvm_shared::crypto::signature::Signature;
     use fvm_shared::econ::TokenAmount;
     use fvm_shared::error::ExitCode;
+    use fvm_shared::METHOD_SEND;
     use ipc_gateway::{Checkpoint, FundParams, SubnetID, MIN_COLLATERAL_AMOUNT};
     use ipc_subnet_actor::{
         Actor, ConsensusType, ConstructParams, JoinParams, Method, State, Status,
     };
+    use num::BigInt;
+    use num_traits::FromPrimitive;
     use num_traits::Zero;
     use primitives::TCid;
     use std::str::FromStr;
@@ -95,6 +98,7 @@ mod test {
 
         let caller = Address::new_id(10);
         let validator = Address::new_id(100);
+        let gateway = Address::new_id(IPC_GATEWAY_ADDR);
         let start_token_value = 5_u64.pow(18);
         let params = JoinParams {
             validator_net_addr: validator.to_string(),
@@ -114,6 +118,15 @@ mod test {
             )
             .unwrap();
 
+        // reward fails because there is no validators.
+        runtime.set_value(value.clone());
+        runtime.set_caller(Cid::default(), gateway.clone());
+        runtime.expect_validate_caller_addr(vec![gateway.clone()]);
+        expect_abort(
+            ExitCode::USR_ILLEGAL_STATE,
+            runtime.call::<Actor>(Method::Reward as u64, &RawBytes::default()),
+        );
+
         // verify state.
         // as the value is less than min collateral, state is initiated
         let st: State = runtime.get_state();
@@ -130,7 +143,7 @@ mod test {
         runtime.set_balance(TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT));
         runtime.expect_validate_caller_any();
         runtime.expect_send(
-            Address::new_id(IPC_GATEWAY_ADDR),
+            gateway.clone(),
             ipc_gateway::Method::Register as u64,
             RawBytes::default(),
             TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT),
@@ -168,7 +181,7 @@ mod test {
         runtime.set_balance(TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT));
         runtime.expect_validate_caller_any();
         runtime.expect_send(
-            Address::new_id(IPC_GATEWAY_ADDR),
+            gateway.clone(),
             ipc_gateway::Method::AddStake as u64,
             RawBytes::default(),
             TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT),
@@ -196,6 +209,39 @@ mod test {
             stake.unwrap(),
             TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT)
         );
+        runtime.verify();
+
+        // reward is fairly distribute among all validators,
+        // and fails if no tokens are sent.
+        runtime.set_value(TokenAmount::zero());
+        runtime.set_caller(Cid::default(), gateway.clone());
+        runtime.expect_validate_caller_addr(vec![gateway.clone()]);
+        expect_abort(
+            ExitCode::USR_ILLEGAL_ARGUMENT,
+            runtime.call::<Actor>(Method::Reward as u64, &RawBytes::default()),
+        );
+
+        let total_reward = TokenAmount::from_atto(2);
+        runtime.set_value(total_reward.clone());
+        runtime.set_caller(Cid::default(), gateway.clone());
+        runtime.expect_validate_caller_addr(vec![gateway.clone()]);
+        runtime.set_balance(TokenAmount::from_atto(3));
+        let st: State = runtime.get_state();
+        let rew_amount =
+            total_reward.div_floor(BigInt::from_usize(st.validator_set.len()).unwrap());
+        for v in st.validator_set.into_iter() {
+            runtime.expect_send(
+                v.addr,
+                METHOD_SEND,
+                RawBytes::default(),
+                rew_amount.clone(),
+                RawBytes::default(),
+                ExitCode::new(0),
+            );
+        }
+        runtime
+            .call::<Actor>(Method::Reward as u64, &RawBytes::default())
+            .unwrap();
         runtime.verify();
     }
 


### PR DESCRIPTION
> Still a draft, do not merge until all items  in the checklist are implemented.

## Changes
- [x] Removes `SCA_ACTOR_ADDR` and uses the right gateway address to call  `REWARD_ACTOR_ADDR` minting.
- [x] Introduces the collection of cross-message fees to a governance account in every cross-net operation.
- [x] Fixes tests to handle cross-msg fees and other minor refactors.
- [x] Remove the automatic propagation of cross-messages from with checkpoint commitments.
- [x] Implements the distribution of rewards from cross-msg fees through checkpoints. See https://github.com/consensus-shipyard/ipc-actors/issues/38
