### PR TITLE
Upgrade actor dependencies and make subnet-actor "buildable"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,15 @@ members = [
     "atomic-exec/primitives",
     "atomic-exec/examples/fungible-token",
 ]
+
+# [patch.crates-io]
+# primitives = { path = "../fvm-utils/primitives" }
+# fil_actors_runtime = { path = "../fvm-utils/runtime" }
+
+# [patch.crates-io]
+# primitives = { git = "https://github.com/consensus-shipyard/fvm-utils", rev = "eff7df493789dec885578dc765a9fa1d7d012ec8" }
+# fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", rev = "eff7df493789dec885578dc765a9fa1d7d012ec8" }
+
+[patch."https://github.com/consensus-shipyard/fvm-utils"]
+primitives = { path = "../fvm-utils/primitives" }
+fil_actors_runtime = { path = "../fvm-utils/runtime" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,7 @@ members = [
     "atomic-exec/examples/fungible-token",
 ]
 
-# [patch.crates-io]
+# Uncomment to point to you local versions
+# [patch."https://github.com/consensus-shipyard/fvm-utils"]
 # primitives = { path = "../fvm-utils/primitives" }
 # fil_actors_runtime = { path = "../fvm-utils/runtime" }
-
-# [patch.crates-io]
-# primitives = { git = "https://github.com/consensus-shipyard/fvm-utils", rev = "eff7df493789dec885578dc765a9fa1d7d012ec8" }
-# fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", rev = "eff7df493789dec885578dc765a9fa1d7d012ec8" }
-
-[patch."https://github.com/consensus-shipyard/fvm-utils"]
-primitives = { path = "../fvm-utils/primitives" }
-fil_actors_runtime = { path = "../fvm-utils/runtime" }

--- a/atomic-exec/Cargo.toml
+++ b/atomic-exec/Cargo.toml
@@ -21,6 +21,7 @@ fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
+frc42_dispatch = "3.0.0"
 
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/atomic-exec/Cargo.toml
+++ b/atomic-exec/Cargo.toml
@@ -3,7 +3,7 @@ name = "ipc_atomic_execution"
 version = "0.0.1"
 license = "MIT OR Apache-2.0"
 authors = ["ConsensusLab", "Protocol Labs", "Filecoin Core Devs"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/consensus-shipyard/ipc-atomic-execution"
 keywords = ["filecoin", "web3", "wasm"]
 
@@ -17,10 +17,10 @@ ipc_gateway = { path = "../gateway", package = "ipc-gateway" }
 
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
 primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
-fvm_shared = { version = "3.0.0-alpha.5", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.3.0"
+fvm_ipld_encoding = "0.3.3"
 
 num-traits = "0.2.14"
 num-derive = "0.3.3"

--- a/atomic-exec/examples/fungible-token/Cargo.toml
+++ b/atomic-exec/examples/fungible-token/Cargo.toml
@@ -20,13 +20,12 @@ ipc_gateway = { path = "../../../gateway", package = "ipc-gateway" }
 fvm_primitives = { git = "https://github.com/consensus-shipyard/fvm-utils", package = "primitives" }
 fvm_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", package = "fil_actors_runtime", features = ["fil-actor"] }
 
-fvm_actor_utils = { version = "3.0.0", git = "https://github.com/helix-onchain/filecoin" }
-frc42_macros = { version = "1.0.0", git = "https://github.com/helix-onchain/filecoin" }
+frc42_dispatch = "3.0.0"
 
-fvm_shared = { version = "3.0.0-alpha.5", default-features = false }
+fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.3.0"
+fvm_ipld_encoding = "0.3.3"
 
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 serde_tuple = "0.5"

--- a/atomic-exec/examples/fungible-token/src/lib.rs
+++ b/atomic-exec/examples/fungible-token/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! [frc-46]: https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0046.md
 
-use frc42_macros::method_hash;
+use frc42_dispatch::method_hash;
 use fvm_actors_runtime::runtime::{ActorCode, Runtime};
 use fvm_actors_runtime::{actor_error, cbor, ActorDowncast, ActorError, INIT_ACTOR_ADDR};
 use fvm_ipld_blockstore::Blockstore;

--- a/atomic-exec/examples/fungible-token/src/state.rs
+++ b/atomic-exec/examples/fungible-token/src/state.rs
@@ -1,6 +1,5 @@
 use fvm_actors_runtime::Map;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::Cbor;
 use fvm_ipld_hamt::BytesKey;
 use fvm_primitives::{TCid, THamt};
 use fvm_shared::{address::Address, bigint::Zero, econ::TokenAmount, ActorID, HAMT_BIT_WIDTH};
@@ -32,7 +31,6 @@ pub struct State {
     /// Atomic execution registry.
     atomic_registry: AtomicExecRegistry,
 }
-impl Cbor for State {}
 
 impl State {
     /// Creates a new actor state instance.

--- a/atomic-exec/primitives/Cargo.toml
+++ b/atomic-exec/primitives/Cargo.toml
@@ -16,4 +16,4 @@ serde_tuple = "0.5"
 serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.3.0"
+fvm_ipld_encoding = "0.3.3"

--- a/atomic-exec/src/state.rs
+++ b/atomic-exec/src/state.rs
@@ -3,7 +3,7 @@
 use cid::multihash::Blake2b256;
 use cid::multihash::Hasher;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
 use fvm_shared::MethodNum;
@@ -20,7 +20,6 @@ pub struct State {
     pub registry: RegistryCid, // H(exec_id, actors) -> pre-commitments
     pub ipc_gateway_address: Address,
 }
-impl Cbor for State {}
 
 type RegistryCid = TCid<THamt<RegistryKey, RegistryEntry>>;
 type RegistryKey = BytesKey;

--- a/atomic-exec/src/types.rs
+++ b/atomic-exec/src/types.rs
@@ -1,5 +1,5 @@
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::MethodNum;
 use ipc_gateway::IPCAddress;
@@ -23,7 +23,6 @@ pub struct PreCommitParams {
     /// Method to call back to commit atomic execution.
     pub commit: MethodNum,
 }
-impl Cbor for PreCommitParams {}
 
 /// Parameters for [crate::Method::Revoke].
 #[derive(Clone, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
@@ -36,4 +35,3 @@ pub struct RevokeParams {
     /// Method to call back to rollback atomic execution.
     pub rollback: MethodNum,
 }
-impl Cbor for RevokeParams {}

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
+frc42_dispatch = "3.0.0"
 primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
 fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 ipc-sdk = { path = "../sdk" }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
 primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
-fvm_shared = { version = "=3.0.0-alpha.5", default-features = false }
+fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 ipc-sdk = { path = "../sdk" }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
@@ -30,7 +30,7 @@ serde_tuple = "0.5"
 serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.3.0"
+fvm_ipld_encoding = "0.3.3"
 thiserror = "1.0.37"
 unsigned-varint = "0.7.1"
 

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-gateway"
-description = "Subnet Coordinator Actor (SCA) for IPC"
+description = "IPC Gateway Actor"
 version = "0.0.1"
 license = "MIT OR Apache-2.0"
 authors = ["ConsensusLab", "Protocol Labs", "Filecoin Core Devs"]

--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -2,7 +2,7 @@ use anyhow::anyhow;
 use cid::multihash::Code;
 use cid::multihash::MultihashDigest;
 use cid::Cid;
-use fvm_ipld_encoding::{serde_bytes, to_vec, Cbor};
+use fvm_ipld_encoding::{serde_bytes, to_vec};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use ipc_sdk::subnet_id::SubnetID;
@@ -17,8 +17,6 @@ pub struct Checkpoint {
     #[serde(with = "serde_bytes")]
     sig: Vec<u8>,
 }
-
-impl Cbor for Checkpoint {}
 
 impl Checkpoint {
     pub fn new(id: SubnetID, epoch: ChainEpoch) -> Self {
@@ -135,7 +133,6 @@ impl CheckData {
         }
     }
 }
-impl Cbor for CheckData {}
 
 // CrossMsgMeta sends an aggregate of all messages being propagated up in
 // the checkpoint.
@@ -146,7 +143,6 @@ pub struct CrossMsgMeta {
     pub value: TokenAmount,
     pub fee: TokenAmount,
 }
-impl Cbor for CrossMsgMeta {}
 
 impl CrossMsgMeta {
     pub fn new() -> Self {
@@ -163,7 +159,6 @@ pub struct ChildCheck {
     pub source: SubnetID,
     pub checks: Vec<TCid<TLink<Checkpoint>>>,
 }
-impl Cbor for ChildCheck {}
 
 /// CheckpointEpoch returns the epoch of the next checkpoint
 /// that needs to be signed

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -5,7 +5,6 @@ use cid::Cid;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::{actor_error, ActorDowncast, ActorError, Map};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::Cbor;
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
@@ -53,8 +52,6 @@ lazy_static! {
     static ref MIN_SUBNET_COLLATERAL: TokenAmount = TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT);
 }
 
-impl Cbor for State {}
-
 impl State {
     pub fn new<BS: Blockstore>(store: &BS, params: ConstructorParams) -> anyhow::Result<State> {
         Ok(State {
@@ -91,11 +88,11 @@ impl State {
     }
 
     /// Register a subnet in the map of subnets and flush.
-    pub(crate) fn register_subnet<BS, RT>(&mut self, rt: &RT, id: &SubnetID) -> anyhow::Result<()>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    pub(crate) fn register_subnet(
+        &mut self,
+        rt: &impl Runtime,
+        id: &SubnetID,
+    ) -> anyhow::Result<()> {
         let val = rt.message().value_received();
         if val < self.min_stake {
             return Err(anyhow!("call to register doesn't include enough funds"));

--- a/gateway/src/subnet.rs
+++ b/gateway/src/subnet.rs
@@ -1,7 +1,6 @@
 use anyhow::anyhow;
 use fil_actors_runtime::runtime::Runtime;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::Cbor;
 use fvm_shared::econ::TokenAmount;
 use primitives::{TAmt, TCid};
 use serde::{Deserialize, Serialize};
@@ -32,19 +31,13 @@ pub struct Subnet {
     pub prev_checkpoint: Option<Checkpoint>,
 }
 
-impl Cbor for Subnet {}
-
 impl Subnet {
-    pub(crate) fn add_stake<BS, RT>(
+    pub(crate) fn add_stake(
         &mut self,
-        rt: &RT,
+        rt: &impl Runtime,
         st: &mut State,
         value: &TokenAmount,
-    ) -> anyhow::Result<()>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
-    {
+    ) -> anyhow::Result<()> {
         self.stake += value;
         if self.stake < st.min_stake {
             self.status = Status::Inactive;

--- a/gateway/src/types.rs
+++ b/gateway/src/types.rs
@@ -2,7 +2,7 @@ use cid::multihash::Code;
 use cid::{multihash, Cid};
 use fil_actors_runtime::{cbor, ActorError, Array};
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
-use fvm_ipld_encoding::{Cbor, RawBytes, DAG_CBOR};
+use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
@@ -71,8 +71,6 @@ pub struct PostBoxItem {
     pub cross_msg: CrossMsg,
     pub owners: Option<Vec<Address>>,
 }
-
-impl Cbor for PostBoxItem {}
 
 // The implementation does not matter, we just need to extract the cid
 impl CodeType for PostBoxItem {

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -1,6 +1,7 @@
 use cid::Cid;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::{BURNT_FUNDS_ACTOR_ADDR, REWARD_ACTOR_ADDR};
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
@@ -347,9 +348,9 @@ fn checkpoint_crossmsgs() {
     rt.expect_send(
         shid.subnet_actor(),
         SUBNET_ACTOR_REWARD_METHOD,
-        RawBytes::default(),
+        None,
         fee,
-        RawBytes::default(),
+        None,
         ExitCode::OK,
     );
     h.commit_child_check(&mut rt, &shid, &ch, ExitCode::OK)
@@ -619,9 +620,9 @@ fn test_apply_msg_bu_target_subnet() {
                 rt.expect_send(
                     sto.clone(),
                     METHOD_SEND,
-                    RawBytes::default(),
+                    None,
                     value.clone(),
-                    RawBytes::default(),
+                    None,
                     ExitCode::OK,
                 );
             })),
@@ -685,11 +686,11 @@ fn test_apply_msg_bu_not_target_subnet() {
     // propagating a bottom-up message triggers the
     // funds included in the message to be burnt.
     rt.expect_send(
-        *BURNT_FUNDS_ACTOR_ADDR,
+        BURNT_FUNDS_ACTOR_ADDR,
         METHOD_SEND,
-        RawBytes::default(),
+        None,
         params.clone().value,
-        RawBytes::default(),
+        None,
         ExitCode::OK,
     );
     h.propagate(
@@ -770,11 +771,11 @@ fn test_propagate_with_remainder() {
     // propagating a bottom-up message triggers the
     // funds included in the message to be burnt.
     rt.expect_send(
-        *BURNT_FUNDS_ACTOR_ADDR,
+        BURNT_FUNDS_ACTOR_ADDR,
         METHOD_SEND,
-        RawBytes::default(),
+        None,
         params.clone().value,
-        RawBytes::default(),
+        None,
         ExitCode::OK,
     );
     h.propagate(&mut rt, caller, cid.clone(), &params.value, value.clone())
@@ -926,23 +927,23 @@ fn test_apply_msg_tp_target_subnet() {
             Some(Box::new(move |rt| {
                 // expect to send reward message
                 rt.expect_send(
-                    *REWARD_ACTOR_ADDR,
+                    REWARD_ACTOR_ADDR,
                     ext::reward::EXTERNAL_FUNDING_METHOD,
-                    RawBytes::serialize(ext::reward::FundingParams {
+                    IpldBlock::serialize_cbor(&ext::reward::FundingParams {
                         addr: *ACTOR,
                         value: v.clone(),
                     })
                     .unwrap(),
                     TokenAmount::zero(),
-                    RawBytes::default(),
+                    None,
                     ExitCode::OK,
                 );
                 rt.expect_send(
                     sto.clone(),
                     METHOD_SEND,
-                    RawBytes::default(),
+                    None,
                     v.clone(),
-                    RawBytes::default(),
+                    None,
                     ExitCode::OK,
                 );
             })),
@@ -1009,15 +1010,15 @@ fn test_apply_msg_tp_not_target_subnet() {
             Some(Box::new(move |rt| {
                 // expect to send reward message
                 rt.expect_send(
-                    *REWARD_ACTOR_ADDR,
+                    REWARD_ACTOR_ADDR,
                     ext::reward::EXTERNAL_FUNDING_METHOD,
-                    RawBytes::serialize(ext::reward::FundingParams {
+                    IpldBlock::serialize_cbor(&ext::reward::FundingParams {
                         addr: *ACTOR,
                         value: v.clone(),
                     })
                     .unwrap(),
                     TokenAmount::zero(),
-                    RawBytes::default(),
+                    None,
                     ExitCode::OK,
                 );
             })),

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["filecoin", "web3", "wasm", "ipc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fvm_ipld_encoding = "0.3.0"
+fvm_ipld_encoding = "0.3.3"
 lazy_static = "1.4.0"
 serde_tuple = "0.5"
 serde = { version = "1.0.136", features = ["derive"] }
-fvm_shared = { version = "=3.0.0-alpha.5", default-features = false }
+fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 thiserror = "1.0.38"
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -1,4 +1,3 @@
-use fvm_ipld_encoding::Cbor;
 use fvm_shared::address::Address;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
@@ -13,7 +12,6 @@ pub struct SubnetID {
     parent: String,
     actor: Address,
 }
-impl Cbor for SubnetID {}
 
 lazy_static! {
     pub static ref ROOTNET_ID: SubnetID = SubnetID {

--- a/subnet-actor/Cargo.toml
+++ b/subnet-actor/Cargo.toml
@@ -8,6 +8,11 @@ edition = "2021"
 repository = "https://github.com/consensus-shipyard/ipc-actors"
 keywords = ["filecoin", "web3", "wasm", "ipc"]
 
+[lib]
+## lib is necessary for integration tests
+## cdylib is necessary for Wasm build
+crate-type = ["cdylib", "lib"]
+
 [dependencies]
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
 ipc-gateway = { path = "../gateway" }

--- a/subnet-actor/Cargo.toml
+++ b/subnet-actor/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
+frc42_dispatch = "3.0.0 "
 ipc-gateway = { path = "../gateway" }
 ipc-sdk = { path = "../sdk" }
 primitives = { git = "https://github.com/consensus-shipyard/fvm-utils"}

--- a/subnet-actor/Cargo.toml
+++ b/subnet-actor/Cargo.toml
@@ -18,7 +18,7 @@ fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", 
 ipc-gateway = { path = "../gateway" }
 ipc-sdk = { path = "../sdk" }
 primitives = { git = "https://github.com/consensus-shipyard/fvm-utils"}
-fvm_shared = { version = "=3.0.0-alpha.5", default-features = false }
+fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 fvm_ipld_hamt = "0.5.1"
 num-traits = "0.2.14"
 num-derive = "0.3.3"
@@ -31,7 +31,7 @@ serde_tuple = "0.5"
 serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.56"
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.3.0"
+fvm_ipld_encoding = "0.3.3"
 thiserror = "1.0.37"
 unsigned-varint = "0.7.1"
 num = "0.4.0"

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -283,9 +283,7 @@ impl State {
     }
 
     /// Do not call this function in transaction
-    pub fn verify_checkpoint(&self, rt: &mut impl Runtime, ch: &Checkpoint) -> anyhow::Result<()>
-
-    {
+    pub fn verify_checkpoint(&self, rt: &mut impl Runtime, ch: &Checkpoint) -> anyhow::Result<()> {
         // check that subnet is active
         if self.status != Status::Active {
             return Err(anyhow!(

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -283,10 +283,8 @@ impl State {
     }
 
     /// Do not call this function in transaction
-    pub fn verify_checkpoint<BS, RT>(&self, rt: &mut RT, ch: &Checkpoint) -> anyhow::Result<()>
-    where
-        BS: Blockstore,
-        RT: Runtime<BS>,
+    pub fn verify_checkpoint(&self, rt: &mut impl Runtime, ch: &Checkpoint) -> anyhow::Result<()>
+
     {
         // check that subnet is active
         if self.status != Status::Active {

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -4,7 +4,7 @@ use fil_actors_runtime::runtime::fvm::resolve_secp_bls;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::{actor_error, ActorError};
 use fvm_ipld_blockstore::Blockstore;
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
@@ -47,8 +47,6 @@ pub struct State {
     pub validator_set: Vec<Validator>,
     pub min_validators: u64,
 }
-
-impl Cbor for State {}
 
 /// We should probably have a derive macro to mark an object as a state object,
 /// and have load and save methods automatically generated for them as part of a

--- a/subnet-actor/src/types.rs
+++ b/subnet-actor/src/types.rs
@@ -1,6 +1,6 @@
+use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_ipld_encoding::repr::*;
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
-use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
@@ -72,12 +72,17 @@ pub struct JoinParams {
 pub(crate) struct CrossActorPayload {
     pub to: Address,
     pub method: MethodNum,
-    pub params: RawBytes,
+    pub params: Option<IpldBlock>,
     pub value: TokenAmount,
 }
 
 impl CrossActorPayload {
-    pub fn new(to: Address, method: MethodNum, params: RawBytes, value: TokenAmount) -> Self {
+    pub fn new(
+        to: Address,
+        method: MethodNum,
+        params: Option<IpldBlock>,
+        value: TokenAmount,
+    ) -> Self {
         Self {
             to,
             method,

--- a/subnet-actor/src/types.rs
+++ b/subnet-actor/src/types.rs
@@ -1,6 +1,6 @@
 use fvm_ipld_encoding::repr::*;
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
-use fvm_ipld_encoding::{Cbor, RawBytes};
+use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
@@ -25,8 +25,6 @@ pub struct Validator {
 pub struct Votes {
     pub validators: Vec<Address>,
 }
-
-impl Cbor for Votes {}
 
 /// Consensus types supported by hierarchical consensus
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize_repr, Serialize_repr)]
@@ -65,13 +63,11 @@ pub struct ConstructParams {
     // param
     pub genesis: Vec<u8>,
 }
-impl Cbor for ConstructParams {}
 
 #[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple, PartialEq, Eq)]
 pub struct JoinParams {
     pub validator_net_addr: String,
 }
-impl Cbor for JoinParams {}
 
 pub(crate) struct CrossActorPayload {
     pub to: Address,


### PR DESCRIPTION
Depends on: https://github.com/consensus-shipyard/fvm-utils/pull/16

This PR: 
- [x] Adds `crate-type` so `subnet_actor` can be compiled into WASM.
- [x] It bump up all fvm dependencies and updates to use the latest version of the `fvm-utils` runtime.
- [x] Use FRC42 method dispatching for all actors.
