### PR TITLE
IPC actors build and general fixes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,14 @@ members = [
 # [patch."https://github.com/consensus-shipyard/fvm-utils"]
 # primitives = { path = "../fvm-utils/primitives" }
 # fil_actors_runtime = { path = "../fvm-utils/runtime" }
+
+[profile.wasm]
+inherits = "release"
+# This needs to be unwind, not abort, so that we can handle panics within our panic hook.
+panic = "unwind"
+overflow-checks = true
+lto = "thin"
+opt-level = 3
+strip = true
+codegen-units = 1
+incremental = false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 build:
-	cargo build -Z unstable-options --release --target=wasm32-unknown-unknown --workspace --out-dir output
+	./build.sh
 
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git checkout next
 # by the builtin-actors bundling script
 export IPC_ACTORS_PATH="<path_to>/ipc-actors/output"
 # Build the bundle
-cargo build
+BUILD_FIL_NETWORK="devnet" cargo build
 ```
 The build command should return a similar output to the following, indicating all the actors that have been bundled and the path of the resulting `.car` file with the bundle.
 ```

--- a/atomic-exec/Cargo.toml
+++ b/atomic-exec/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-ipc_gateway = { path = "../gateway", package = "ipc-gateway" }
+ipc_gateway = { path = "../gateway", package = "ipc-gateway", features = [] }
 
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
 primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+OUTPUT_DIR="${IPC_OUTPUT_DIR:=output}"  
+
+rm -rf $OUTPUT_DIR/*
+echo "Cleaning output directory $OUTPUT_DIR"
+WASM_FLAGS="-Z unstable-options --target=wasm32-unknown-unknown --profile=wasm --locked --out-dir ${OUTPUT_DIR}"
+
+echo "building IPC gateway"
+GATEWAY_FLAGS="-p=ipc-gateway --features=fil-gateway-actor"
+cargo build $WASM_FLAGS $GATEWAY_FLAGS
+
+echo "building the rest of ipc-actors"
+IPC_FLAGS="-p=ipc-subnet-actor -p=ipc_atomic_execution --features=fil-actor"
+cargo build $WASM_FLAGS $IPC_FLAGS

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -46,4 +46,4 @@ wasm-builder = "3.0.1"
 wasmtime = "0.35.2"
 
 [features]
-fil-actor = []
+fil-gateway-actor = []

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -27,7 +27,7 @@ use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use primitives::TCid;
 
-#[cfg(feature = "fil-actor")]
+#[cfg(feature = "fil-gateway-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
 pub mod checkpoint;

--- a/subnet-actor/Cargo.toml
+++ b/subnet-actor/Cargo.toml
@@ -45,3 +45,6 @@ base64 = "0.13.1"
 [build-dependencies]
 wasm-builder = "3.0.1"
 wasmtime = "0.35.2"
+
+[features]
+fil-actor = []

--- a/subnet-actor/src/lib.rs
+++ b/subnet-actor/src/lib.rs
@@ -19,6 +19,8 @@ use num_traits::{FromPrimitive, Zero};
 
 pub use crate::state::State;
 pub use crate::types::*;
+
+#[cfg(feature = "fil-actor")]
 fil_actors_runtime::wasm_trampoline!(Actor);
 
 /// Atomic execution coordinator actor methods available


### PR DESCRIPTION
## Background 
While trying to build the actors I realized that `ipc-subnet-actor` and `ipc_atomic_execution` make use of `ipc-gateway` as a library to access some convenient methods and types. This led to getting a `duplicate symbol invoke error` as the the two actors where being built in the same wasm module. This is one of the reasons for the `fil-actor` feature that embeds (or not) the `wasm_trampoline` according to if we want to compile the actors as a wams module or a wasm library. This behavior has already been seen and documented [here](https://github.com/filecoin-project/builtin-actors/issues/109) (refer to that issue for additional context).

## Implementation
This PR includes a new `fil-gateway-actor` feature to enable the compilation of the gateway as a wasm module, to prevent from clashing with the general-purpose `fil-actor` feature, allowing it to be used as a library for the `subnet-actor` and the `atomic_execution`.

It also updates the `make build` script and updates the README.   