### PR TITLE
mint circ.supply without modified reward actor

### DIFF
--- a/gateway/src/ext.rs
+++ b/gateway/src/ext.rs
@@ -1,17 +1,3 @@
 pub mod account {
     pub const PUBKEY_ADDRESS_METHOD: u64 = 2;
 }
-
-pub mod reward {
-    use fvm_shared::address::Address;
-    use fvm_shared::econ::TokenAmount;
-    use serde::{Deserialize, Serialize};
-
-    pub const EXTERNAL_FUNDING_METHOD: u64 = 5;
-
-    #[derive(Serialize, Deserialize, Clone)]
-    pub struct FundingParams {
-        pub value: TokenAmount,
-        pub addr: Address,
-    }
-}

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -1,7 +1,6 @@
 use cid::Cid;
 use fil_actors_runtime::runtime::Runtime;
-use fil_actors_runtime::{BURNT_FUNDS_ACTOR_ADDR, REWARD_ACTOR_ADDR};
-use fvm_ipld_encoding::ipld_block::IpldBlock;
+use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
@@ -11,7 +10,7 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::METHOD_SEND;
 use ipc_gateway::Status::{Active, Inactive};
 use ipc_gateway::{
-    ext, get_topdown_msg, Checkpoint, CrossMsg, IPCAddress, State, StorableMsg, CROSS_MSG_FEE,
+    get_topdown_msg, Checkpoint, CrossMsg, IPCAddress, State, StorableMsg, CROSS_MSG_FEE,
     DEFAULT_CHECKPOINT_PERIOD, SUBNET_ACTOR_REWARD_METHOD,
 };
 use ipc_sdk::subnet_id::SubnetID;
@@ -939,19 +938,6 @@ fn test_apply_msg_tp_target_subnet() {
             value.clone(),
             params,
             Some(Box::new(move |rt| {
-                // expect to send reward message
-                rt.expect_send(
-                    REWARD_ACTOR_ADDR,
-                    ext::reward::EXTERNAL_FUNDING_METHOD,
-                    IpldBlock::serialize_cbor(&ext::reward::FundingParams {
-                        addr: *ACTOR,
-                        value: v.clone(),
-                    })
-                    .unwrap(),
-                    TokenAmount::zero(),
-                    None,
-                    ExitCode::OK,
-                );
                 rt.expect_send(
                     sto.clone(),
                     METHOD_SEND,
@@ -1014,29 +1000,9 @@ fn test_apply_msg_tp_not_target_subnet() {
         params: RawBytes::default(),
         nonce: msg_nonce,
     };
-    let v = value.clone();
     // cid is expected, should not be None
     let cid = h
-        .apply_cross_execute_only(
-            &mut rt,
-            value.clone(),
-            params.clone(),
-            Some(Box::new(move |rt| {
-                // expect to send reward message
-                rt.expect_send(
-                    REWARD_ACTOR_ADDR,
-                    ext::reward::EXTERNAL_FUNDING_METHOD,
-                    IpldBlock::serialize_cbor(&ext::reward::FundingParams {
-                        addr: *ACTOR,
-                        value: v.clone(),
-                    })
-                    .unwrap(),
-                    TokenAmount::zero(),
-                    None,
-                    ExitCode::OK,
-                );
-            })),
-        )
+        .apply_cross_execute_only(&mut rt, value.clone(), params.clone(), None)
         .unwrap()
         .unwrap();
 

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -11,8 +11,7 @@ use fil_actors_runtime::test_utils::{
     SUBNET_ACTOR_CODE_ID, SYSTEM_ACTOR_CODE_ID,
 };
 use fil_actors_runtime::{
-    make_map_with_root_and_bitwidth, ActorError, Map, BURNT_FUNDS_ACTOR_ADDR, REWARD_ACTOR_ADDR,
-    SYSTEM_ACTOR_ADDR,
+    make_map_with_root_and_bitwidth, ActorError, Map, BURNT_FUNDS_ACTOR_ADDR, SYSTEM_ACTOR_ADDR,
 };
 use fil_actors_runtime::{Array, INIT_ACTOR_ADDR};
 use fvm_ipld_blockstore::Blockstore;
@@ -656,18 +655,6 @@ impl Harness {
             let st: State = rt.get_state();
             assert_eq!(st.applied_bottomup_nonce, msg_nonce);
         } else {
-            let rew_params = ext::reward::FundingParams {
-                addr: *ACTOR,
-                value: params.value.clone(),
-            };
-            rt.expect_send(
-                REWARD_ACTOR_ADDR,
-                ext::reward::EXTERNAL_FUNDING_METHOD,
-                IpldBlock::serialize_cbor(&rew_params).unwrap(),
-                TokenAmount::zero(),
-                None,
-                ExitCode::OK,
-            );
             if sto == st.network_name {
                 rt.expect_send(
                     rto,


### PR DESCRIPTION
Fixes https://github.com/consensus-shipyard/ipc-actors/issues/45.

The gateway actor for subnets is currently spawned in genesis. In order to simplify the way new circulating supply is minted in subnets, we have removed the need of a modified reward actor. The balance that is usually provisioned in genesis to the `RewardActor` is now provisioned in genesis to the gateway. This balance is the one used to mint new circulating supply when a top-down message is executed.

In the future, we may provision this initial balance to a modified `IPCRewardActor` in order to decouple the gateway's balance from the total circulating supply in the subnet to prevent potential attacks. The `IPCRewardActor` could also be used in the future for developers to be able to design their own custom reward distribution policies in subnets.  