### PR TITLE
set manifestID keys to actors

### DIFF
--- a/atomic-exec/src/lib.rs
+++ b/atomic-exec/src/lib.rs
@@ -13,7 +13,9 @@ use ipc_gateway::{ApplyMsgParams, CrossMsg, IPCAddress, StorableMsg, SubnetID};
 use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Zero};
 
-pub use crate::types::{AtomicExecID, ConstructorParams, PreCommitParams, RevokeParams};
+pub use crate::types::{
+    AtomicExecID, ConstructorParams, PreCommitParams, RevokeParams, MANIFEST_ID,
+};
 
 mod state;
 mod types;

--- a/atomic-exec/src/types.rs
+++ b/atomic-exec/src/types.rs
@@ -4,6 +4,9 @@ use fvm_shared::address::Address;
 use fvm_shared::MethodNum;
 use ipc_gateway::IPCAddress;
 
+/// ID used in the builtin-actors bundle manifest
+pub const MANIFEST_ID: &str = "ipc_atomic_execution";
+
 /// Concise identifier of an atomic execution instance.
 pub type AtomicExecID = RawBytes;
 

--- a/gateway/src/types.rs
+++ b/gateway/src/types.rs
@@ -14,6 +14,9 @@ use serde::{Deserialize, Serialize};
 use crate::checkpoint::{Checkpoint, CrossMsgMeta};
 use crate::cross::CrossMsg;
 
+/// ID used in the builtin-actors bundle manifest
+pub const MANIFEST_ID: &str = "ipc_gateway";
+
 pub const CROSSMSG_AMT_BITWIDTH: u32 = 3;
 pub const DEFAULT_CHECKPOINT_PERIOD: ChainEpoch = 10;
 pub const MAX_NONCE: u64 = u64::MAX;

--- a/subnet-actor/src/types.rs
+++ b/subnet-actor/src/types.rs
@@ -8,6 +8,9 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::MethodNum;
 use ipc_gateway::SubnetID;
 
+/// ID used in the builtin-actors bundle manifest
+pub const MANIFEST_ID: &str = "ipc_subnet_actor";
+
 /// Optional leaving coefficient to penalize
 /// validators leaving the subnet.
 // It should be a float between 0-1 but


### PR DESCRIPTION
This PR sets the `ManifestID` key set to all actors in the builtin-actors bundle. By exposing this type we ensure that other code bases (like the IPC-agent or our custom bundling tool) are using the same (and correct) value.
