### PR TITLE
fix serialization of all actor states and related components

### DIFF
--- a/atomic-exec/examples/fungible-token/src/state.rs
+++ b/atomic-exec/examples/fungible-token/src/state.rs
@@ -8,13 +8,12 @@ use ipc_atomic_execution_primitives::{
     AtomicExecID, AtomicExecRegistry, AtomicInputID, AtomicInputState,
 };
 use ipc_gateway::IPCAddress;
-use serde::{Deserialize, Serialize};
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 pub type AccountState = AtomicInputState<TokenAmount>;
 
 /// Represents the state of the actor.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct State {
     /// Address of the IPC gateway actor.
     ipc_gateway: Address,

--- a/atomic-exec/primitives/src/lib.rs
+++ b/atomic-exec/primitives/src/lib.rs
@@ -9,7 +9,6 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::Deserialize_tuple;
 use fvm_ipld_encoding::{CborStore, RawBytes, DAG_CBOR};
 use fvm_primitives::{TCid, THamt};
-use serde::Deserialize;
 use serde::{self, de::DeserializeOwned, Serialize};
 use serde_tuple::Serialize_tuple;
 
@@ -183,7 +182,7 @@ struct AtomicOutputEntry {
 /// bigger data structure, or referred to by its CID. In the latter
 /// case, it is user's responsibility to flush to and load from the
 /// blockstore.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct AtomicExecRegistry {
     nonce: AtomicExecNonce,
     input_ids: TCid<THamt<AtomicInputID, AtomicInputEntry>>,

--- a/atomic-exec/src/state.rs
+++ b/atomic-exec/src/state.rs
@@ -9,13 +9,13 @@ use fvm_shared::address::Address;
 use fvm_shared::MethodNum;
 use ipc_gateway::IPCAddress;
 use primitives::{TCid, THamt};
-use serde::{Deserialize, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use std::collections::HashMap;
 
 use crate::types::AtomicExecID;
 use crate::ConstructorParams;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct State {
     pub registry: RegistryCid, // H(exec_id, actors) -> pre-commitments
     pub ipc_gateway_address: Address,

--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -7,11 +7,11 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use ipc_sdk::subnet_id::SubnetID;
 use primitives::{TCid, TLink};
-use serde::{Deserialize, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use crate::CrossMsgs;
 
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct Checkpoint {
     pub data: CheckData,
     #[serde(with = "serde_bytes")]
@@ -111,7 +111,7 @@ impl Checkpoint {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct CheckData {
     pub source: SubnetID,
     #[serde(with = "serde_bytes")]
@@ -136,7 +136,7 @@ impl CheckData {
 
 // CrossMsgMeta sends an aggregate of all messages being propagated up in
 // the checkpoint.
-#[derive(PartialEq, Eq, Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Default, Serialize_tuple, Deserialize_tuple)]
 pub struct CrossMsgMeta {
     pub msgs_cid: TCid<TLink<CrossMsgs>>,
     pub nonce: u64,
@@ -154,7 +154,7 @@ impl CrossMsgMeta {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct ChildCheck {
     pub source: SubnetID,
     pub checks: Vec<TCid<TLink<Checkpoint>>>,

--- a/gateway/src/cross.rs
+++ b/gateway/src/cross.rs
@@ -15,7 +15,7 @@ use fvm_shared::METHOD_SEND;
 use ipc_sdk::address::IPCAddress;
 use ipc_sdk::subnet_id::SubnetID;
 use primitives::{TCid, TLink};
-use serde::{Deserialize, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use std::path::Path;
 
 /// StorableMsg stores all the relevant information required
@@ -25,7 +25,7 @@ use std::path::Path;
 /// as we did in the actor's Go counter-part. Instead we just persist the
 /// information required to create the cross-messages and execute in the
 /// corresponding node implementation.
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct StorableMsg {
     pub from: IPCAddress,
     pub to: IPCAddress,
@@ -35,7 +35,7 @@ pub struct StorableMsg {
     pub nonce: u64,
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct CrossMsg {
     pub msg: StorableMsg,
     pub wrapped: bool,
@@ -145,7 +145,7 @@ pub fn is_bottomup(from: &SubnetID, to: &SubnetID) -> bool {
     Path::new(&a).components().count() - 1 > index
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Default, Serialize_tuple, Deserialize_tuple)]
 pub struct CrossMsgs {
     // FIXME: Consider to make this an AMT if we expect
     // a lot of cross-messages to be propagated.

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -13,7 +13,7 @@ use fvm_shared::error::ExitCode;
 use lazy_static::lazy_static;
 use num_traits::Zero;
 use primitives::{TAmt, TCid, THamt, TLink};
-use serde::{Deserialize, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use std::str::FromStr;
 
 use ipc_sdk::subnet_id::SubnetID;
@@ -29,7 +29,7 @@ use super::types::*;
 type PostBox = TCid<THamt<Cid, Vec<u8>>>;
 
 /// Storage power actor state
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct State {
     pub network_name: SubnetID,
     pub total_subnets: u64,

--- a/gateway/src/subnet.rs
+++ b/gateway/src/subnet.rs
@@ -1,9 +1,10 @@
 use anyhow::anyhow;
 use fil_actors_runtime::runtime::Runtime;
 use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::repr::{Deserialize_repr, Serialize_repr};
 use fvm_shared::econ::TokenAmount;
 use primitives::{TAmt, TCid};
-use serde::{Deserialize, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use crate::CROSSMSG_AMT_BITWIDTH;
 use ipc_sdk::subnet_id::SubnetID;
@@ -12,7 +13,7 @@ use super::checkpoint::*;
 use super::cross::CrossMsg;
 use super::state::State;
 
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize_repr, Serialize_repr)]
 #[repr(i32)]
 pub enum Status {
     Active,
@@ -20,7 +21,7 @@ pub enum Status {
     Killed,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple, PartialEq, Eq)]
 pub struct Subnet {
     pub id: SubnetID,
     pub stake: TokenAmount,

--- a/gateway/src/types.rs
+++ b/gateway/src/types.rs
@@ -9,7 +9,6 @@ use fvm_shared::econ::TokenAmount;
 use ipc_sdk::subnet_id::SubnetID;
 use multihash::MultihashDigest;
 use primitives::CodeType;
-use serde::{Deserialize, Serialize};
 
 use crate::checkpoint::{Checkpoint, CrossMsgMeta};
 use crate::cross::CrossMsg;
@@ -33,7 +32,7 @@ pub struct ConstructorParams {
     pub checkpoint_period: ChainEpoch,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
 pub struct FundParams {
     pub value: TokenAmount,
 }

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -3,7 +3,7 @@ use crate::subnet_id::SubnetID;
 use fil_actors_runtime::cbor;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
-use serde_tuple::{Serialize_tuple, Deserialize_tuple};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use std::str::FromStr;
 
 const IPC_SEPARATOR_ADDR: &str = ":";

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -3,12 +3,12 @@ use crate::subnet_id::SubnetID;
 use fil_actors_runtime::cbor;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
-use serde::{Deserialize, Serialize};
+use serde_tuple::{Serialize_tuple, Deserialize_tuple};
 use std::str::FromStr;
 
 const IPC_SEPARATOR_ADDR: &str = ":";
 
-#[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash, Serialize_tuple, Deserialize_tuple)]
 pub struct IPCAddress {
     subnet_id: SubnetID,
     raw_address: Address,

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -4,6 +4,7 @@ use fil_actors_runtime::runtime::fvm::resolve_secp_bls;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::{actor_error, ActorError};
 use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::serde_bytes;
 use fvm_ipld_encoding::RawBytes;
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
@@ -15,7 +16,7 @@ use lazy_static::lazy_static;
 use num::rational::Ratio;
 use num::BigInt;
 use primitives::{TCid, THamt};
-use serde::{Deserialize, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use crate::types::*;
 
@@ -27,7 +28,7 @@ lazy_static! {
 }
 
 /// The state object.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct State {
     pub name: String,
     /// The parent id of the subnet actor, it should be the same as the
@@ -39,6 +40,7 @@ pub struct State {
     pub total_stake: TokenAmount,
     pub stake: TCid<THamt<Cid, TokenAmount>>,
     pub status: Status,
+    #[serde(with = "serde_bytes")]
     pub genesis: Vec<u8>,
     pub finality_threshold: ChainEpoch,
     pub check_period: ChainEpoch,


### PR DESCRIPTION
In order for Rust object to be compatible with the expected serialization in Go, they needs to be serialized as tuples not maps. This PR performs that change to ensure this compatibility. 
