### PR TITLE
Rename tipset and remove explicit sig. in checkpoints

### DIFF
--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -114,8 +114,10 @@ impl Checkpoint {
 #[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct CheckData {
     pub source: SubnetID,
+    // subnet-specific proof propagated as part of the checkpoint (initially we propagate)
+    // a pointer to the tipset at the specific epoch of  the checkpoint.
     #[serde(with = "serde_bytes")]
-    pub tip_set: Vec<u8>,
+    pub proof: Vec<u8>,
     pub epoch: ChainEpoch,
     pub prev_check: TCid<TLink<Checkpoint>>,
     pub children: Vec<ChildCheck>,
@@ -125,7 +127,7 @@ impl CheckData {
     pub fn new(id: SubnetID, epoch: ChainEpoch) -> Self {
         Self {
             source: id,
-            tip_set: Vec::new(),
+            proof: Vec::new(),
             epoch,
             prev_check: TCid::default(),
             children: Vec::new(),

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -1,11 +1,9 @@
 use anyhow::anyhow;
 use cid::Cid;
-use fil_actors_runtime::runtime::fvm::resolve_secp_bls;
 use fil_actors_runtime::runtime::Runtime;
 use fil_actors_runtime::{actor_error, ActorError};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::serde_bytes;
-use fvm_ipld_encoding::RawBytes;
 use fvm_ipld_hamt::BytesKey;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
@@ -315,14 +313,17 @@ impl State {
         }
 
         // check signature
-        let caller = rt.message().caller();
-        let pkey = resolve_secp_bls(rt, &caller)?;
+        // NOTE: In the current implementation the validator is the one sending the message
+        // including the checkpoint, so there is no need for a explicit signature in checkpoints,
+        // they are implicitly signed by signing the submission message.
+        // let caller = rt.message().caller();
+        // let pkey = resolve_secp_bls(rt, &caller)?;
 
-        rt.verify_signature(
-            &RawBytes::deserialize(&ch.signature().clone().into())?,
-            &pkey,
-            &ch.cid().to_bytes(),
-        )?;
+        // rt.verify_signature(
+        //     &RawBytes::deserialize(&ch.signature().clone().into())?,
+        //     &pkey,
+        //     &ch.cid().to_bytes(),
+        // )?;
 
         Ok(())
     }

--- a/subnet-actor/tests/actor_test.rs
+++ b/subnet-actor/tests/actor_test.rs
@@ -2,9 +2,7 @@
 mod test {
     use cid::Cid;
     use fil_actors_runtime::runtime::Runtime;
-    use fil_actors_runtime::test_utils::{
-        expect_abort, ExpectedVerifySig, MockRuntime, INIT_ACTOR_CODE_ID,
-    };
+    use fil_actors_runtime::test_utils::{expect_abort, MockRuntime, INIT_ACTOR_CODE_ID};
     use fil_actors_runtime::{ActorError, INIT_ACTOR_ADDR};
     use fvm_ipld_encoding::ipld_block::IpldBlock;
     use fvm_ipld_encoding::RawBytes;
@@ -673,21 +671,23 @@ mod test {
         is_commit: bool,
     ) -> Result<Option<IpldBlock>, ActorError> {
         runtime.set_caller(Cid::default(), sender.clone());
-        runtime.expect_send(
-            sender.clone(),
-            ipc_sdk::account::PUBKEY_ADDRESS_METHOD as u64,
-            None,
-            TokenAmount::zero(),
-            IpldBlock::serialize_cbor(&sender).unwrap(),
-            ExitCode::new(0),
-        );
         runtime.expect_validate_caller_any();
-        runtime.expect_verify_signature(ExpectedVerifySig {
-            sig: Signature::new_secp256k1(vec![1, 2, 3, 4]),
-            signer: sender.clone(),
-            plaintext: checkpoint.cid().to_bytes(),
-            result: Ok(()),
-        });
+        // runtime.expect_send(
+        //     sender.clone(),
+        //     ipc_sdk::account::PUBKEY_ADDRESS_METHOD as u64,
+        //     None,
+        //     TokenAmount::zero(),
+        //     IpldBlock::serialize_cbor(&sender).unwrap(),
+        //     ExitCode::new(0),
+        // );
+        // NOTE: For M2 we are removing the explicit signature
+        // verification from checkpoints.
+        // runtime.expect_verify_signature(ExpectedVerifySig {
+        //     sig: Signature::new_secp256k1(vec![1, 2, 3, 4]),
+        //     signer: sender.clone(),
+        //     plaintext: checkpoint.cid().to_bytes(),
+        //     result: Ok(()),
+        // });
 
         if is_commit {
             runtime.expect_send(


### PR DESCRIPTION
Simplifies checkpoint submission by removing explicit signature and renames `tip_set` field to make it more general and avoid confusion. 
