### PR TITLE
Add config_number to validator set

### DIFF
--- a/subnet-actor/src/lib.rs
+++ b/subnet-actor/src/lib.rs
@@ -210,7 +210,7 @@ impl SubnetActor for Actor {
                 ));
             }
 
-            if !st.validator_set.is_empty() || st.total_stake != TokenAmount::zero() {
+            if !st.validator_set.validators().is_empty() || st.total_stake != TokenAmount::zero() {
                 return Err(actor_error!(
                     illegal_state,
                     "this subnet can only be killed when all validators have left"
@@ -340,10 +340,10 @@ impl SubnetActor for Actor {
         // complex and fair policies to incentivize certain behaviors.
         // we may even have a default one for IPC.
         let div = {
-            if st.validator_set.len() == 0 {
+            if st.validator_set.validators().len() == 0 {
                 return Err(actor_error!(illegal_state, "no validators in subnet"));
             };
-            match BigInt::from_usize(st.validator_set.len()) {
+            match BigInt::from_usize(st.validator_set.validators().len()) {
                 None => {
                     return Err(actor_error!(illegal_state, "couldn't convert into BigInt"));
                 }
@@ -351,7 +351,7 @@ impl SubnetActor for Actor {
             }
         };
         let rew_amount = amount.div_floor(div);
-        for v in st.validator_set.into_iter() {
+        for v in st.validator_set.validators().into_iter() {
             rt.send(&v.addr, METHOD_SEND, None, rew_amount.clone())?;
         }
         Ok(None)

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -165,14 +165,25 @@ impl State {
             self.total_stake += amount;
 
             // check if the miner has collateral to become a validator
-            if updated_stake >= self.min_validator_stake
-                && (self.consensus != ConsensusType::Delegated
-                    || self.validator_set.validators().is_empty())
-            {
-                self.validator_set.push(Validator {
-                    addr: *addr,
-                    net_addr: String::from(net_addr),
-                });
+            if updated_stake >= self.min_validator_stake {
+                // check if it is already a validator
+                if !self
+                    .validator_set
+                    .validators()
+                    .iter()
+                    .any(|x| x.addr == *addr)
+                    && (self.consensus != ConsensusType::Delegated
+                        || self.validator_set.validators().is_empty())
+                {
+                    self.validator_set.push(Validator {
+                        addr: *addr,
+                        net_addr: String::from(net_addr),
+                        weight: updated_stake,
+                    });
+                } else {
+                    // update the weight if it is already a validator
+                    self.validator_set.update_weight(addr, &updated_stake)
+                }
             }
 
             Ok(true)

--- a/subnet-actor/src/types.rs
+++ b/subnet-actor/src/types.rs
@@ -23,6 +23,9 @@ pub const TESTING_ID: u64 = 339;
 pub struct Validator {
     pub addr: Address,
     pub net_addr: String,
+    // voting power for the validator determined by its stake in the
+    // network.
+    pub weight: TokenAmount,
 }
 
 #[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple, PartialEq, Eq)]
@@ -44,6 +47,10 @@ impl ValidatorSet {
         &self.validators
     }
 
+    pub fn validators_mut(&mut self) -> &mut Vec<Validator> {
+        &mut self.validators
+    }
+
     pub fn config_number(&self) -> u64 {
         self.config_number
     }
@@ -61,6 +68,15 @@ impl ValidatorSet {
         self.validators.retain(|x| x.addr != *val);
         // update the config_number with every update
         // we allow config_number to overflow if that scenario ever comes.
+        self.config_number += 1;
+    }
+
+    pub fn update_weight(&mut self, val: &Address, weight: &TokenAmount) {
+        self.validators_mut()
+            .iter_mut()
+            .filter(|x| x.addr == *val)
+            .for_each(|x| x.weight = weight.clone());
+
         self.config_number += 1;
     }
 }

--- a/subnet-actor/src/types.rs
+++ b/subnet-actor/src/types.rs
@@ -26,6 +26,46 @@ pub struct Validator {
 }
 
 #[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple, PartialEq, Eq)]
+pub struct ValidatorSet {
+    validators: Vec<Validator>,
+    // sequence number that uniquely identifies a validator set
+    config_number: u64,
+}
+
+impl ValidatorSet {
+    pub fn new() -> Self {
+        Self {
+            validators: Vec::new(),
+            config_number: 0,
+        }
+    }
+
+    pub fn validators(&self) -> &Vec<Validator> {
+        &self.validators
+    }
+
+    pub fn config_number(&self) -> u64 {
+        self.config_number
+    }
+
+    /// Push a new validator to the validator set.
+    pub fn push(&mut self, val: Validator) {
+        self.validators.push(val);
+        // update the config_number with every update
+        // we allow config_number to overflow if that scenario ever comes.
+        self.config_number += 1;
+    }
+
+    /// Remove a validator from validator set by address
+    pub fn rm(&mut self, val: &Address) {
+        self.validators.retain(|x| x.addr != *val);
+        // update the config_number with every update
+        // we allow config_number to overflow if that scenario ever comes.
+        self.config_number += 1;
+    }
+}
+
+#[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple, PartialEq, Eq)]
 pub struct Votes {
     pub validators: Vec<Address>,
 }

--- a/subnet-actor/tests/actor_test.rs
+++ b/subnet-actor/tests/actor_test.rs
@@ -87,7 +87,7 @@ mod test {
         assert_eq!(state.name, NETWORK_NAME);
         assert_eq!(state.ipc_gateway_addr, Address::new_id(IPC_GATEWAY_ADDR));
         assert_eq!(state.total_stake, TokenAmount::zero());
-        assert_eq!(state.validator_set.is_empty(), true);
+        assert_eq!(state.validator_set.validators().is_empty(), true);
     }
 
     #[test]
@@ -148,7 +148,8 @@ mod test {
         // verify state.
         // as the value is less than min collateral, state is initiated
         let st: State = runtime.get_state();
-        assert_eq!(st.validator_set.len(), 0);
+        assert_eq!(st.validator_set.validators().len(), 0);
+        assert_eq!(st.validator_set.config_number(), 0);
         assert_eq!(st.status, Status::Instantiated);
         assert_eq!(st.total_stake, value);
         let stake = st.get_stake(runtime.store(), &caller).unwrap();
@@ -178,7 +179,8 @@ mod test {
         // verify state.
         // as the value is less than min collateral, state is active
         let st: State = runtime.get_state();
-        assert_eq!(st.validator_set.len(), 1);
+        assert_eq!(st.validator_set.validators().len(), 1);
+        assert_eq!(st.validator_set.config_number(), 1);
         assert_eq!(st.status, Status::Active);
         assert_eq!(
             st.total_stake,
@@ -216,7 +218,8 @@ mod test {
         // verify state.
         // as the value is less than min collateral, state is active
         let st: State = runtime.get_state();
-        assert_eq!(st.validator_set.len(), 2);
+        assert_eq!(st.validator_set.validators().len(), 2);
+        assert_eq!(st.validator_set.config_number(), 2);
         assert_eq!(st.status, Status::Active);
         assert_eq!(
             st.total_stake,
@@ -245,9 +248,9 @@ mod test {
         runtime.expect_validate_caller_addr(vec![gateway.clone()]);
         runtime.set_balance(TokenAmount::from_atto(3));
         let st: State = runtime.get_state();
-        let rew_amount =
-            total_reward.div_floor(BigInt::from_usize(st.validator_set.len()).unwrap());
-        for v in st.validator_set.into_iter() {
+        let rew_amount = total_reward
+            .div_floor(BigInt::from_usize(st.validator_set.validators().len()).unwrap());
+        for v in st.validator_set.validators().into_iter() {
             runtime.expect_send(
                 v.addr,
                 METHOD_SEND,
@@ -330,7 +333,8 @@ mod test {
 
         let st: State = runtime.get_state();
         assert_eq!(st.total_stake, total_stake);
-        assert_eq!(st.validator_set.len(), 2);
+        assert_eq!(st.validator_set.validators().len(), 2);
+        assert_eq!(st.validator_set.config_number(), 2);
         assert_eq!(
             st.get_stake(runtime.store(), &caller).unwrap().unwrap(),
             TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT)
@@ -364,7 +368,7 @@ mod test {
             .unwrap();
         let st: State = runtime.get_state();
         assert_eq!(st.total_stake, total_stake);
-        assert_eq!(st.validator_set.len(), 2);
+        assert_eq!(st.validator_set.validators().len(), 2);
         assert_eq!(
             st.get_stake(runtime.store(), &caller).unwrap().unwrap(),
             value
@@ -400,7 +404,8 @@ mod test {
         runtime.call::<Actor>(Method::Leave as u64, None).unwrap();
 
         let st: State = runtime.get_state();
-        assert_eq!(st.validator_set.len(), 1);
+        assert_eq!(st.validator_set.validators().len(), 1);
+        assert_eq!(st.validator_set.config_number(), 3);
         assert_eq!(st.status, Status::Active);
         assert_eq!(st.total_stake, total_stake);
         assert_eq!(
@@ -445,7 +450,8 @@ mod test {
         runtime.call::<Actor>(Method::Leave as u64, None).unwrap();
 
         let st: State = runtime.get_state();
-        assert_eq!(st.validator_set.len(), 0);
+        assert_eq!(st.validator_set.validators().len(), 0);
+        assert_eq!(st.validator_set.config_number(), 4);
         assert_eq!(st.status, Status::Inactive);
         assert_eq!(st.total_stake, total_stake);
         assert_eq!(
@@ -481,7 +487,7 @@ mod test {
         );
         runtime.call::<Actor>(Method::Leave as u64, None).unwrap();
         let st: State = runtime.get_state();
-        assert_eq!(st.validator_set.len(), 0);
+        assert_eq!(st.validator_set.validators().len(), 0);
         assert_eq!(st.status, Status::Inactive);
         assert_eq!(st.total_stake, total_stake);
         assert_eq!(
@@ -563,7 +569,7 @@ mod test {
 
         // verify that we have an active subnet with 3 validators.
         let st: State = runtime.get_state();
-        assert_eq!(st.validator_set.len(), 3);
+        assert_eq!(st.validator_set.validators().len(), 3);
         assert_eq!(st.status, Status::Active);
 
         // Generate the check point


### PR DESCRIPTION
Mir integration in Lotus needs a config number to sync reconfiguration requests between validators. This PR introduces a `config_number` to the actor state to support reconfigurations in Mir triggered by on-chain state for IPC subnets. 

//cc @cryptoAtwill, consider this change for https://github.com/consensus-shipyard/ipc-agent/pull/76?no-redirect=1
//cc @dnkolegov to review this is the expected behavior.