### PR TITLE
add weight to validators

### DIFF
--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -165,14 +165,25 @@ impl State {
             self.total_stake += amount;
 
             // check if the miner has collateral to become a validator
-            if updated_stake >= self.min_validator_stake
-                && (self.consensus != ConsensusType::Delegated
-                    || self.validator_set.validators().is_empty())
-            {
-                self.validator_set.push(Validator {
-                    addr: *addr,
-                    net_addr: String::from(net_addr),
-                });
+            if updated_stake >= self.min_validator_stake {
+                // check if it is already a validator
+                if !self
+                    .validator_set
+                    .validators()
+                    .iter()
+                    .any(|x| x.addr == *addr)
+                    && (self.consensus != ConsensusType::Delegated
+                        || self.validator_set.validators().is_empty())
+                {
+                    self.validator_set.push(Validator {
+                        addr: *addr,
+                        net_addr: String::from(net_addr),
+                        weight: updated_stake,
+                    });
+                } else {
+                    // update the weight if it is already a validator
+                    self.validator_set.update_weight(addr, &updated_stake)
+                }
             }
 
             Ok(true)

--- a/subnet-actor/src/types.rs
+++ b/subnet-actor/src/types.rs
@@ -23,6 +23,9 @@ pub const TESTING_ID: u64 = 339;
 pub struct Validator {
     pub addr: Address,
     pub net_addr: String,
+    // voting power for the validator determined by its stake in the
+    // network.
+    pub weight: TokenAmount,
 }
 
 #[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple, PartialEq, Eq)]
@@ -44,6 +47,10 @@ impl ValidatorSet {
         &self.validators
     }
 
+    pub fn validators_mut(&mut self) -> &mut Vec<Validator> {
+        &mut self.validators
+    }
+
     pub fn config_number(&self) -> u64 {
         self.config_number
     }
@@ -61,6 +68,15 @@ impl ValidatorSet {
         self.validators.retain(|x| x.addr != *val);
         // update the config_number with every update
         // we allow config_number to overflow if that scenario ever comes.
+        self.config_number += 1;
+    }
+
+    pub fn update_weight(&mut self, val: &Address, weight: &TokenAmount) {
+        self.validators_mut()
+            .iter_mut()
+            .filter(|x| x.addr == *val)
+            .for_each(|x| x.weight = weight.clone());
+
         self.config_number += 1;
     }
 }


### PR DESCRIPTION
This PR: 
- Adds a weight to validators so we can use weighted voting in Mir
- It fixes a bug for which a validator which was already part of the subnet was being added twice in the validator set when calling join to add additional stake. 