### PR TITLE
New method: set network address for validator

### DIFF
--- a/subnet-actor/src/lib.rs
+++ b/subnet-actor/src/lib.rs
@@ -33,6 +33,7 @@ pub enum Method {
     Leave = frc42_dispatch::method_hash!("Leave"),
     Kill = frc42_dispatch::method_hash!("Kill"),
     SubmitCheckpoint = frc42_dispatch::method_hash!("SubmitCheckpoint"),
+    SetValidatorNetAddr = frc42_dispatch::method_hash!("SetValidatorNetAddr"),
     Reward = frc42_dispatch::method_hash!("Reward"),
 }
 
@@ -358,6 +359,38 @@ impl SubnetActor for Actor {
     }
 }
 
+/// This impl includes methods that are not required by the subnet actor
+/// trait.
+impl Actor {
+    /// Sets a new net address to an existing validator
+    pub fn set_validator_net_addr(
+        rt: &mut impl Runtime,
+        params: JoinParams,
+    ) -> Result<Option<RawBytes>, ActorError> {
+        rt.validate_immediate_caller_type(CALLER_TYPES_SIGNABLE.iter())?;
+        let caller = rt.message().caller();
+
+        rt.transaction(|st: &mut State, _rt| {
+            // if the caller is a validator allow him to change his net addr
+            if let Some(index) = st
+                .validator_set
+                .validators()
+                .iter()
+                .position(|x| x.addr == caller)
+            {
+                st.validator_set
+                    .validators_mut()
+                    .get_mut(index)
+                    .map(|x| x.net_addr = params.validator_net_addr);
+            } else {
+                return Err(actor_error!(forbidden, "caller is not a validator"));
+            }
+            Ok(())
+        })?;
+        Ok(None)
+    }
+}
+
 impl ActorCode for Actor {
     type Methods = Method;
 
@@ -368,5 +401,6 @@ impl ActorCode for Actor {
         Kill => kill,
         SubmitCheckpoint => submit_checkpoint,
         Reward => reward,
+        SetValidatorNetAddr => set_validator_net_addr,
     }
 }

--- a/subnet-actor/src/types.rs
+++ b/subnet-actor/src/types.rs
@@ -22,6 +22,8 @@ pub const TESTING_ID: u64 = 339;
 #[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple, PartialEq, Eq)]
 pub struct Validator {
     pub addr: Address,
+    // TODO: We currently support a single validator address for validators,
+    // in the future we should consider supporting more than one multiaddr.
     pub net_addr: String,
     // voting power for the validator determined by its stake in the
     // network.


### PR DESCRIPTION
If a user made a mistake or changed its validators net address, we didn't provide a way for them to change their validator's multiaddress. I experienced this problem while testing :facepalm:

This PR adds a method in the subnet actor that users can use to change the multiaddress of their validator. 

When this PR is merged: 
- [ ] Add the updated actor bundle to Eudico. 
- [ ] Add a new method in the ipc_agent to set the multiaddr of a validator. 