### PR TITLE
checkpoint fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           profile: minimal
           target: wasm32-unknown-unknown
-          toolchain: nightly
+          toolchain: nightly-2022-10-03
           override: true
       - run: cargo b --all --release
       - run: cargo t --all --release
@@ -49,7 +49,7 @@ jobs:
         with:
           profile: minimal
           target: wasm32-unknown-unknown
-          toolchain: nightly
+          toolchain: nightly-2022-10-03
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1

--- a/gateway/build.rs
+++ b/gateway/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     use wasm_builder::WasmBuilder;
+
     WasmBuilder::new()
         .with_current_project()
         .import_memory()

--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -2,14 +2,24 @@ use anyhow::anyhow;
 use cid::multihash::Code;
 use cid::multihash::MultihashDigest;
 use cid::Cid;
+use fvm_ipld_encoding::DAG_CBOR;
 use fvm_ipld_encoding::{serde_bytes, to_vec};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use ipc_sdk::subnet_id::SubnetID;
+use lazy_static::lazy_static;
 use primitives::{TCid, TLink};
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use crate::CrossMsgs;
+
+lazy_static! {
+    // Default CID used for the genesis checkpoint. Using
+    // TCid::default() leads to corrupting the fvm datastore
+    // for storing the cid of an inaccessible HAMT.
+    pub static ref CHECKPOINT_GENESIS_CID: Cid =
+        Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest("genesis".as_bytes()));
+}
 
 #[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct Checkpoint {
@@ -129,7 +139,7 @@ impl CheckData {
             source: id,
             proof: Vec::new(),
             epoch,
-            prev_check: TCid::default(),
+            prev_check: CHECKPOINT_GENESIS_CID.clone().into(),
             children: Vec::new(),
             cross_msgs: None,
         }

--- a/gateway/src/cross.rs
+++ b/gateway/src/cross.rs
@@ -228,12 +228,12 @@ mod tests {
 
     #[test]
     fn test_is_bottomup() {
-        bottom_up("/root/f01", "/root/f01/f02", false);
-        bottom_up("/root/f01", "/root", true);
-        bottom_up("/root/f01", "/root/f01/f02", false);
-        bottom_up("/root/f01", "/root/f02/f02", true);
-        bottom_up("/root/f01/f02", "/root/f01/f02", false);
-        bottom_up("/root/f01/f02", "/root/f01/f02/f03", false);
+        bottom_up("/root/t01", "/root/t01/t02", false);
+        bottom_up("/root/t01", "/root", true);
+        bottom_up("/root/t01", "/root/t01/t02", false);
+        bottom_up("/root/t01", "/root/t02/t02", true);
+        bottom_up("/root/t01/t02", "/root/t01/t02", false);
+        bottom_up("/root/t01/t02", "/root/t01/t02/t03", false);
     }
     fn bottom_up(a: &str, b: &str, res: bool) {
         assert_eq!(

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(let_chains)] // For some simpler syntax for if let Some conditions
 
-pub use self::checkpoint::{Checkpoint, CrossMsgMeta};
+pub use self::checkpoint::{Checkpoint, CrossMsgMeta, CHECKPOINT_GENESIS_CID};
 pub use self::cross::{is_bottomup, CrossMsg, CrossMsgs, IPCMsgType, StorableMsg};
 pub use self::state::*;
 pub use self::subnet::*;
@@ -73,7 +73,7 @@ impl Actor {
         let st = State::new(rt.store(), params).map_err(|e| {
             e.downcast_default(
                 ExitCode::USR_ILLEGAL_STATE,
-                "Failed to create SCA actor state",
+                "Failed to create gateway actor state",
             )
         })?;
         rt.create(&st)?;

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -10,6 +10,7 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
+use ipc_sdk::epoch_key;
 use lazy_static::lazy_static;
 use num_traits::Zero;
 use primitives::{TAmt, TCid, THamt, TLink};
@@ -36,6 +37,8 @@ pub struct State {
     pub min_stake: TokenAmount,
     pub subnets: TCid<THamt<SubnetID, Subnet>>,
     pub check_period: ChainEpoch,
+    // FIXME: Consider making checkpoints a HAMT instead of an AMT so we use
+    // the AMT index instead of and epoch k for object indexing.
     pub checkpoints: TCid<THamt<ChainEpoch, Checkpoint>>,
     pub check_msg_registry: TCid<THamt<TCid<TLink<CrossMsgs>>, CrossMsgs>>,
     /// `postbox` keeps track for an EOA of all the cross-net messages triggered by
@@ -172,7 +175,7 @@ impl State {
         let ch_epoch = checkpoint_epoch(epoch, self.check_period);
         let checkpoints = self.checkpoints.load(store)?;
 
-        Ok(match get_checkpoint(&checkpoints, &ch_epoch)? {
+        Ok(match get_checkpoint(&checkpoints, ch_epoch)? {
             Some(ch) => ch.clone(),
             None => Checkpoint::new(self.network_name.clone(), ch_epoch),
         })
@@ -476,17 +479,17 @@ pub fn set_checkpoint<BS: Blockstore>(
 ) -> anyhow::Result<()> {
     let epoch = ch.epoch();
     checkpoints
-        .set(BytesKey::from(epoch.to_ne_bytes().to_vec()), ch)
+        .set(epoch_key(epoch), ch)
         .map_err(|e| e.downcast_wrap(format!("failed to set checkpoint for epoch {}", epoch)))?;
     Ok(())
 }
 
-fn get_checkpoint<'m, BS: Blockstore>(
+pub fn get_checkpoint<'m, BS: Blockstore>(
     checkpoints: &'m Map<BS, Checkpoint>,
-    epoch: &ChainEpoch,
+    epoch: ChainEpoch,
 ) -> anyhow::Result<Option<&'m Checkpoint>> {
     checkpoints
-        .get(&BytesKey::from(epoch.to_ne_bytes().to_vec()))
+        .get(&epoch_key(epoch))
         .map_err(|e| e.downcast_wrap(format!("failed to get checkpoint for id {}", epoch)))
 }
 

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -492,7 +492,7 @@ fn test_send_cross() {
         .unwrap();
 
     // top-down
-    let sub = SubnetID::from_str("/root/f0101/f0101").unwrap();
+    let sub = SubnetID::from_str("/root/t0101/t0101").unwrap();
     h.send_cross(
         &mut rt,
         &from,
@@ -505,7 +505,7 @@ fn test_send_cross() {
         &value,
     )
     .unwrap();
-    let sub = SubnetID::from_str("/root/f0101/f0101").unwrap();
+    let sub = SubnetID::from_str("/root/t0101/t0101").unwrap();
     let circ_sup = 2 * &value;
     h.send_cross(
         &mut rt,
@@ -519,7 +519,7 @@ fn test_send_cross() {
         &circ_sup,
     )
     .unwrap();
-    let sub = SubnetID::from_str("/root/f0101/f0101/f01002").unwrap();
+    let sub = SubnetID::from_str("/root/t0101/t0101/t01002").unwrap();
     let circ_sup = circ_sup.clone() + &value;
     h.send_cross(
         &mut rt,
@@ -536,7 +536,7 @@ fn test_send_cross() {
 
     // bottom-up
     rt.set_balance(3 * &value);
-    let sub = SubnetID::from_str("/root/f0102/f0101").unwrap();
+    let sub = SubnetID::from_str("/root/t0102/t0101").unwrap();
     let zero = TokenAmount::zero();
     h.send_cross(
         &mut rt,
@@ -550,7 +550,7 @@ fn test_send_cross() {
         &zero,
     )
     .unwrap();
-    let sub = SubnetID::from_str("/root/f0102/f0101").unwrap();
+    let sub = SubnetID::from_str("/root/t0102/t0101").unwrap();
     h.send_cross(
         &mut rt,
         &from,

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -17,4 +17,6 @@ serde_tuple = "0.5"
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 thiserror = "1.0.38"
+num-traits = "0.2.14"
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
+integer-encoding = { version = "3.0.3", default-features = false }

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -78,7 +78,7 @@ mod tests {
     fn test_ipc_address() {
         let act = Address::new_id(1001);
         let sub_id = SubnetID::new_from_parent(&ROOTNET_ID.clone(), act);
-        let bls = Address::from_str("f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a").unwrap();
+        let bls = Address::from_str("t3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a").unwrap();
         let haddr = IPCAddress::new(&sub_id, &bls).unwrap();
 
         let str = haddr.to_string().unwrap();

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,6 +1,36 @@
+use fil_actors_runtime::fvm_ipld_hamt::BytesKey;
+use fvm_shared::{
+    address::{set_current_network, Network},
+    clock::ChainEpoch,
+};
+use integer_encoding::VarInt;
+use num_traits::cast::FromPrimitive;
+
 pub mod address;
 pub mod error;
 pub mod subnet_id;
+
+/// Sets the type of network from an environmental variable.
+/// This is key to set the right network prefixes on string
+/// representation of addresses.
+pub fn set_network_from_env() {
+    let network_raw: u8 = std::env::var("LOTUS_NETWORK")
+        // default to testnet
+        .unwrap_or_else(|_| String::from("1"))
+        .parse()
+        .unwrap();
+    let network = Network::from_u8(network_raw).unwrap();
+    set_current_network(network);
+}
+
+/// Encodes the a ChainEpoch as a varInt for its use
+/// as a key of a HAMT. This serialization has been
+/// tested to be compatible with its go counter-part
+/// in github.com/consensus-shipyard/go-ipc-types
+pub fn epoch_key(k: ChainEpoch) -> BytesKey {
+    let bz = k.encode_var_vec();
+    bz.into()
+}
 
 pub mod account {
     /// Public key account actor method.

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -158,6 +158,8 @@ impl fmt::Display for SubnetID {
         // FIXME: This is a horrible hack, and it makes me feel dirty,
         // but it is the only way to ensure that we are picking up
         // the right network address for the environment.
+        // Future fix being tracked here:
+        // https://github.com/consensus-shipyard/ipc-actors/issues/78
         set_network_from_env();
 
         if self.parent == "/root" && self.actor == Address::new_id(0) {

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use crate::error::Error;
+use crate::set_network_from_env;
 
 #[derive(PartialEq, Eq, Hash, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct SubnetID {
@@ -154,6 +155,11 @@ impl SubnetID {
 
 impl fmt::Display for SubnetID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // FIXME: This is a horrible hack, and it makes me feel dirty,
+        // but it is the only way to ensure that we are picking up
+        // the right network address for the environment.
+        set_network_from_env();
+
         if self.parent == "/root" && self.actor == Address::new_id(0) {
             return write!(f, "{}", self.parent);
         }
@@ -221,7 +227,7 @@ mod tests {
         let act = Address::new_id(1001);
         let sub_id = SubnetID::new_from_parent(&ROOTNET_ID.clone(), act);
         let sub_id_str = sub_id.to_string();
-        assert_eq!(sub_id_str, "/root/f01001");
+        assert_eq!(sub_id_str, "/root/t01001");
 
         let rtt_id = SubnetID::from_str(&sub_id_str).unwrap();
         assert_eq!(sub_id, rtt_id);
@@ -234,20 +240,20 @@ mod tests {
 
     #[test]
     fn test_common_parent() {
-        common_parent("/root/f01", "/root/f01/f02", "/root/f01", 2);
-        common_parent("/root/f01/f02/f03", "/root/f01/f02", "/root/f01/f02", 3);
-        common_parent("/root/f01/f03/f04", "/root/f02/f03/f04", "/root", 1);
+        common_parent("/root/t01", "/root/t01/t02", "/root/t01", 2);
+        common_parent("/root/t01/t02/t03", "/root/t01/t02", "/root/t01/t02", 3);
+        common_parent("/root/t01/t03/t04", "/root/t02/t03/t04", "/root", 1);
         common_parent(
-            "/root/f01/f03/f04",
-            "/root/f01/f03/f04/f05",
-            "/root/f01/f03/f04",
+            "/root/t01/t03/t04",
+            "/root/t01/t03/t04/t05",
+            "/root/t01/t03/t04",
             4,
         );
         // The common parent of the same subnet is the current subnet
         common_parent(
-            "/root/f01/f03/f04",
-            "/root/f01/f03/f04",
-            "/root/f01/f03/f04",
+            "/root/t01/t03/t04",
+            "/root/t01/t03/t04",
+            "/root/t01/t03/t04",
             4,
         );
     }
@@ -255,49 +261,49 @@ mod tests {
     #[test]
     fn test_down() {
         down(
-            "/root/f01/f02/f03",
-            "/root/f01",
-            Some(SubnetID::from_str("/root/f01/f02").unwrap()),
+            "/root/t01/t02/t03",
+            "/root/t01",
+            Some(SubnetID::from_str("/root/t01/t02").unwrap()),
         );
         down(
-            "/root/f01/f02/f03",
-            "/root/f01/f02",
-            Some(SubnetID::from_str("/root/f01/f02/f03").unwrap()),
+            "/root/t01/t02/t03",
+            "/root/t01/t02",
+            Some(SubnetID::from_str("/root/t01/t02/t03").unwrap()),
         );
         down(
-            "/root/f01/f03/f04",
-            "/root/f01/f03",
-            Some(SubnetID::from_str("/root/f01/f03/f04").unwrap()),
+            "/root/t01/t03/t04",
+            "/root/t01/t03",
+            Some(SubnetID::from_str("/root/t01/t03/t04").unwrap()),
         );
-        down("/root", "/root/f01", None);
-        down("/root/f01", "/root/f01", None);
-        down("/root/f02/f03", "/root/f01/f03/f04", None);
-        down("/root", "/root/f01", None);
+        down("/root", "/root/t01", None);
+        down("/root/t01", "/root/t01", None);
+        down("/root/t02/t03", "/root/t01/t03/t04", None);
+        down("/root", "/root/t01", None);
     }
 
     #[test]
     fn test_up() {
         up(
-            "/root/f01/f02/f03",
-            "/root/f01",
+            "/root/t01/t02/t03",
+            "/root/t01",
             Some(SubnetID::from_str("/root").unwrap()),
         );
         up(
-            "/root/f01/f02/f03",
-            "/root/f01/f02",
-            Some(SubnetID::from_str("/root/f01").unwrap()),
+            "/root/t01/t02/t03",
+            "/root/t01/t02",
+            Some(SubnetID::from_str("/root/t01").unwrap()),
         );
-        up("/root", "/root/f01", None);
-        up("/root/f02/f03", "/root/f01/f03/f04", None);
+        up("/root", "/root/t01", None);
+        up("/root/t02/t03", "/root/t01/t03/t04", None);
         up(
-            "/root/f01/f02/f03",
-            "/root/f01/f02",
-            Some(SubnetID::from_str("/root/f01").unwrap()),
+            "/root/t01/t02/t03",
+            "/root/t01/t02",
+            Some(SubnetID::from_str("/root/t01").unwrap()),
         );
         up(
-            "/root/f01/f02/f03",
-            "/root/f01/f02/f03",
-            Some(SubnetID::from_str("/root/f01/f02").unwrap()),
+            "/root/t01/t02/t03",
+            "/root/t01/t02/t03",
+            Some(SubnetID::from_str("/root/t01/t02").unwrap()),
         );
     }
 

--- a/subnet-actor/src/lib.rs
+++ b/subnet-actor/src/lib.rs
@@ -259,9 +259,12 @@ impl SubnetActor for Actor {
             return Err(actor_error!(illegal_state, "not validator"));
         }
 
-        state
-            .verify_checkpoint(rt, &ch)
-            .map_err(|_| actor_error!(illegal_state, "checkpoint failed"))?;
+        state.verify_checkpoint(rt, &ch).map_err(|e| {
+            actor_error!(
+                illegal_state,
+                format!("checkpoint failed: {}", e.to_string())
+            )
+        })?;
 
         let mut msg = None;
 
@@ -315,7 +318,7 @@ impl SubnetActor for Actor {
             Ok(())
         })?;
 
-        // propagate to sca
+        // propagate to gateway
         if let Some(p) = msg {
             rt.send(&p.to, p.method, p.params, p.value)?;
         }

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -9,7 +9,9 @@ use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
+use ipc_gateway::checkpoint::CHECKPOINT_GENESIS_CID;
 use ipc_gateway::{Checkpoint, SubnetID, DEFAULT_CHECKPOINT_PERIOD, MIN_COLLATERAL_AMOUNT};
+use ipc_sdk::epoch_key;
 use lazy_static::lazy_static;
 use num::rational::Ratio;
 use num::BigInt;
@@ -42,6 +44,8 @@ pub struct State {
     pub genesis: Vec<u8>,
     pub finality_threshold: ChainEpoch,
     pub check_period: ChainEpoch,
+    // FIXME: Consider making checkpoints a HAMT instead of an AMT so we use
+    // the AMT index instead of and epoch k for object indexing.
     pub checkpoints: TCid<THamt<ChainEpoch, Checkpoint>>,
     pub window_checks: TCid<THamt<Cid, Votes>>,
     pub validator_set: ValidatorSet,
@@ -274,14 +278,14 @@ impl State {
     fn get_checkpoint<BS: Blockstore>(
         &self,
         store: &BS,
-        epoch: &ChainEpoch,
+        epoch: ChainEpoch,
     ) -> anyhow::Result<Option<Checkpoint>> {
         let hamt = self
             .checkpoints
             .load(store)
             .map_err(|e| anyhow!("failed to load checkpoints: {}", e))?;
         let checkpoint = hamt
-            .get(&BytesKey::from(epoch.to_ne_bytes().to_vec()))
+            .get(&epoch_key(epoch))
             .map_err(|e| anyhow!("failed to get checkpoint for id {}: {:?}", epoch, e))?
             .cloned();
         Ok(checkpoint)
@@ -304,7 +308,7 @@ impl State {
         }
 
         // check that a checkpoint for the epoch doesn't exist already.
-        if self.get_checkpoint(rt.store(), &ch.epoch())?.is_some() {
+        if self.get_checkpoint(rt.store(), ch.epoch())?.is_some() {
             return Err(anyhow!("cannot submit checkpoint for epoch"));
         };
 
@@ -350,14 +354,14 @@ impl State {
     ) -> anyhow::Result<Cid> {
         let mut epoch = epoch - self.check_period;
         while epoch >= 0 {
-            match self.get_checkpoint(store, &epoch)? {
+            match self.get_checkpoint(store, epoch)? {
                 Some(ch) => return Ok(ch.cid()),
                 None => {
                     epoch -= self.check_period;
                 }
             }
         }
-        Ok(Cid::default())
+        Ok(CHECKPOINT_GENESIS_CID.clone())
     }
 
     pub fn flush_checkpoint<BS: Blockstore>(
@@ -367,7 +371,7 @@ impl State {
     ) -> anyhow::Result<()> {
         let epoch = ch.epoch();
         self.checkpoints.modify(store, |hamt| {
-            hamt.set(BytesKey::from(epoch.to_ne_bytes().to_vec()), ch.clone())
+            hamt.set(epoch_key(epoch), ch.clone())
                 .map_err(|e| anyhow!("failed to set checkpoint: {:?}", e))?;
             Ok(true)
         })?;

--- a/subnet-actor/tests/actor_test.rs
+++ b/subnet-actor/tests/actor_test.rs
@@ -14,7 +14,7 @@ mod test {
     use fvm_shared::econ::TokenAmount;
     use fvm_shared::error::ExitCode;
     use fvm_shared::METHOD_SEND;
-    use ipc_gateway::{Checkpoint, FundParams, SubnetID, MIN_COLLATERAL_AMOUNT};
+    use ipc_gateway::{get_checkpoint, Checkpoint, FundParams, SubnetID, MIN_COLLATERAL_AMOUNT};
     use ipc_subnet_actor::{
         Actor, ConsensusType, ConstructParams, JoinParams, Method, State, Status,
     };
@@ -740,6 +740,9 @@ mod test {
         let st: State = runtime.get_state();
         let votes = st.get_votes(runtime.store(), &checkpoint_0.cid()).unwrap();
         assert_eq!(votes.is_none(), true);
+        // check if the checkpoint is committed
+        let checkpoints = st.checkpoints.load(runtime.store()).unwrap();
+        get_checkpoint(&checkpoints, epoch).unwrap();
 
         // Trying to submit an already committed checkpoint should fail
         let sender2 = miners.get(2).cloned().unwrap();


### PR DESCRIPTION
This PR fixes many of the bugs encountered while testing the commitment of checkpoints: 
- It introduces the use of a new `CHECKPOINT_GENESIS_CID` used in the first checkpoint of committed for a subnet. The reason for this is that using `TCid::default()` as `PrevCheck` led to the actor trying to load from the datastore and nonexistent HAMT corrupting the VM state. This is a intermediate work around that requires less refactoring. The proper fix will is tracked in this issue: https://github.com/consensus-shipyard/ipc-actors/issues/77
- Introduces the use of a `varInt` encoding for `ChainEpoch` when used as keys for a HAMT. There was an inconsistency on how the keys for epochs were being computed in Rust and Go. This is also fixed in the Go side with this PR: https://github.com/consensus-shipyard/go-ipc-types/pull/16
- Finally, the encoding of `SubnetID` relies on setting the right type of network to compute the address-side of the ID. Setting consistently among all the crates has shown to be difficult, as a fix, we read from the same environmental variable that Lotus uses to determine the type of network to ensure that Subnet IDs are being computed consistently end-to-end in Rust and Go. In the future, we should improve the encoding of SubnetID so it doesn't depend on the type of network. This fix is tracked here: https://github.com/consensus-shipyard/ipc-actors/issues/78