### PR TITLE
fix store cross-msg in checkpoint

### DIFF
--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -201,14 +201,18 @@ pub struct ChildCheck {
 /// frozen and that is ready for signing and commitment in the
 /// current window.
 pub fn checkpoint_epoch(epoch: ChainEpoch, period: ChainEpoch) -> ChainEpoch {
+    // TODO: Once we consider different genesis_epoch different to zero
+    // we should account for this here.
     (epoch / period) * period
 }
 
 /// WindowEpoch returns the epoch of the active checkpoint window
 ///
-/// Determines the epoch to which new checkpoints and xshard transactions need
-/// to be assigned.
+/// Determines the epoch to which new checkpoints and cross-net transactions need
+/// to be assigned (i.e. the next checkpoint to be committed)
 pub fn window_epoch(epoch: ChainEpoch, period: ChainEpoch) -> ChainEpoch {
+    // TODO: Once we consider different genesis_epoch different to zero
+    // we should account for this here.
     let ind = epoch / period;
     period * (ind + 1)
 }

--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -84,8 +84,8 @@ impl BottomUpCheckpoint {
 
     /// Take the cross messages out of the checkpoint. This will empty the `self.data.cross_msgs`
     /// and replace with None.
-    pub fn take_cross_msgs(&mut self) -> Option<Vec<CrossMsg>> {
-        self.data.cross_msgs.cross_msgs.take()
+    pub fn cross_msgs(&mut self) -> Option<Vec<CrossMsg>> {
+        self.data.cross_msgs.cross_msgs.clone()
     }
 
     pub fn ensure_cross_msgs_sorted(&self) -> anyhow::Result<()> {

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -360,7 +360,7 @@ impl Actor {
                         e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "error flushing checkpoint")
                     })?;
 
-                    let cross_msgs = commit.take_cross_msgs();
+                    let cross_msgs = commit.cross_msgs();
 
                     // update prev_check for child
                     sub.prev_checkpoint = Some(commit);

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -183,7 +183,7 @@ impl State {
         if epoch < 0 {
             return Err(anyhow!("epoch can't be negative"));
         }
-        let ch_epoch = checkpoint_epoch(epoch, self.bottomup_check_period);
+        let ch_epoch = window_epoch(epoch, self.bottomup_check_period);
         let checkpoints = self.bottomup_checkpoints.load(store)?;
 
         Ok(match get_checkpoint(&checkpoints, ch_epoch)? {

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -14,7 +14,7 @@ use ipc_gateway::checkpoint::{window_epoch, BatchCrossMsgs};
 use ipc_gateway::Status::{Active, Inactive};
 use ipc_gateway::{
     get_topdown_msg, BottomUpCheckpoint, CrossMsg, IPCAddress, PostBoxItem, State, StorableMsg,
-    TopDownCheckpoint, CROSS_MSG_FEE, DEFAULT_CHECKPOINT_PERIOD, SUBNET_ACTOR_REWARD_METHOD,
+    TopDownCheckpoint, CROSS_MSG_FEE, SUBNET_ACTOR_REWARD_METHOD,
 };
 use ipc_sdk::subnet_id::SubnetID;
 use ipc_sdk::{epoch_key, Validator, ValidatorSet};


### PR DESCRIPTION
This PR fixes a bug for which bottom-up cross-messages and child checkpoints were being stored in a checkpoint template from the past, preventing it from being successfully propagated to the parent. 