### PR TITLE
fix how applied_bottomup_nonce is handled

### DIFF
--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -49,7 +49,6 @@ pub struct State {
     /// an actor that need to be propagated further through the hierarchy.
     pub postbox: PostBox,
     pub bottomup_nonce: u64,
-    pub applied_bottomup_nonce: u64,
     pub applied_topdown_nonce: u64,
     pub topdown_checkpoint_voting: Voting<TopDownCheckpoint>,
     pub validators: Validators,
@@ -79,7 +78,6 @@ impl State {
             bottomup_nonce: Default::default(),
             // This way we ensure that the first message to execute has nonce= 0, if not it would expect 1 and fail for the first nonce
             // We first increase to the subsequent and then execute for bottom-up messages
-            applied_bottomup_nonce: Default::default(),
             applied_topdown_nonce: Default::default(),
             topdown_checkpoint_voting: Voting::<TopDownCheckpoint>::new(
                 store,
@@ -90,9 +88,9 @@ impl State {
         })
     }
 
-    /// Get content for a child subnet.
+    /// Get content for a child subnet as mut.
     pub fn get_subnet<BS: Blockstore>(
-        &self,
+        &mut self,
         store: &BS,
         id: &SubnetID,
     ) -> anyhow::Result<Option<Subnet>> {
@@ -124,6 +122,7 @@ impl State {
                     status: Status::Active,
                     topdown_nonce: 0,
                     prev_checkpoint: None,
+                    applied_bottomup_nonce: 0,
                 };
                 set_subnet(subnets, id, subnet)?;
                 Ok(true)

--- a/gateway/src/subnet.rs
+++ b/gateway/src/subnet.rs
@@ -29,6 +29,7 @@ pub struct Subnet {
     pub circ_supply: TokenAmount,
     pub status: Status,
     pub prev_checkpoint: Option<BottomUpCheckpoint>,
+    pub applied_bottomup_nonce: u64,
 }
 
 impl Subnet {
@@ -42,6 +43,17 @@ impl Subnet {
         if self.stake < st.min_stake {
             self.status = Status::Inactive;
         }
+        st.flush_subnet(rt.store(), self)?;
+        Ok(())
+    }
+
+    /// Increase the applied bottom-up nonce after an execution.
+    pub(crate) fn increase_applied_bottomup(
+        &mut self,
+        rt: &mut impl Runtime,
+        st: &mut State,
+    ) -> anyhow::Result<()> {
+        self.applied_bottomup_nonce += 1;
         st.flush_subnet(rt.store(), self)?;
         Ok(())
     }

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -273,6 +273,9 @@ fn checkpoint_commit() {
     let child_check = has_childcheck_source(&commit.data.children, &shid).unwrap();
     assert_eq!(&child_check.checks.len(), &1);
     assert_eq!(has_cid(&child_check.checks, &ch.cid()), true);
+    // check that the checkpoint was committed successfully in the subnet as previous checkpoint.
+    let subnet = h.get_subnet(&rt, &shid).unwrap();
+    assert_eq!(subnet.prev_checkpoint.unwrap(), ch);
 
     // Commit a checkpoint for subnet twice
     h.commit_child_check(&mut rt, &shid, &ch, ExitCode::USR_ILLEGAL_ARGUMENT)
@@ -326,6 +329,9 @@ fn checkpoint_commit() {
     let child_check = has_childcheck_source(&commit.data.children, &shid_two).unwrap();
     assert_eq!(&child_check.checks.len(), &1);
     assert_eq!(has_cid(&child_check.checks, &ch.cid()), true);
+    // check that the checkpoint was committed successfully in the subnet as previous checkpoint.
+    let subnet = h.get_subnet(&rt, &shid_two).unwrap();
+    assert_eq!(subnet.prev_checkpoint.unwrap(), ch);
 }
 
 #[test]
@@ -392,6 +398,9 @@ fn checkpoint_crossmsgs() {
     assert_eq!(&child_check.checks.len(), &1);
     let prev_cid = ch.cid();
     assert_eq!(has_cid(&child_check.checks, &prev_cid), true);
+    // check that the checkpoint was committed successfully in the subnet as previous checkpoint.
+    let subnet = h.get_subnet(&rt, &shid).unwrap();
+    assert_eq!(subnet.prev_checkpoint.unwrap(), ch);
 
     // TODO: More extensive tests?
 }

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -102,7 +102,6 @@ impl Harness {
         assert_eq!(st.network_name, self.net_name);
         assert_eq!(st.min_stake, TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT));
         assert_eq!(st.bottomup_check_period, DEFAULT_CHECKPOINT_PERIOD);
-        assert_eq!(st.applied_bottomup_nonce, 0);
         assert_eq!(
             st.topdown_checkpoint_voting.submission_period(),
             *DEFAULT_TOPDOWN_PERIOD


### PR DESCRIPTION
This PR includes: 
- Fixes how `applied_bottomup_nonce` is handled. Before there was a shared bottom_up nonces for the execution of every subnet, but sharing a nonce for all child subnets removes the separation between them and could lead to a subnet stalling the ability to exchange cross-net messages for all other child subnets. This improvement over the execution of cross-net messages fixes this problem.
- A test to catch a bug that we fixed for which the committed previous checkpoint for a subnet was being modified before being persisted fixed in this PR: https://github.com/consensus-shipyard/ipc-actors/pull/89 This test should catch future regressions. 
