### PR TITLE
Require subnet initialization to set genesis epoch correctly

### DIFF
--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -49,7 +49,6 @@ pub struct State {
     /// an actor that need to be propagated further through the hierarchy.
     pub postbox: PostBox,
     pub bottomup_nonce: u64,
-    pub applied_bottomup_nonce: u64,
     pub applied_topdown_nonce: u64,
     pub topdown_checkpoint_voting: Voting<TopDownCheckpoint>,
     pub validators: Validators,
@@ -79,7 +78,6 @@ impl State {
             bottomup_nonce: Default::default(),
             // This way we ensure that the first message to execute has nonce= 0, if not it would expect 1 and fail for the first nonce
             // We first increase to the subsequent and then execute for bottom-up messages
-            applied_bottomup_nonce: Default::default(),
             applied_topdown_nonce: Default::default(),
             topdown_checkpoint_voting: Voting::<TopDownCheckpoint>::new(
                 store,
@@ -90,9 +88,9 @@ impl State {
         })
     }
 
-    /// Get content for a child subnet.
+    /// Get content for a child subnet as mut.
     pub fn get_subnet<BS: Blockstore>(
-        &self,
+        &mut self,
         store: &BS,
         id: &SubnetID,
     ) -> anyhow::Result<Option<Subnet>> {
@@ -124,6 +122,7 @@ impl State {
                     status: Status::Active,
                     topdown_nonce: 0,
                     prev_checkpoint: None,
+                    applied_bottomup_nonce: 0,
                 };
                 set_subnet(subnets, id, subnet)?;
                 Ok(true)

--- a/gateway/src/subnet.rs
+++ b/gateway/src/subnet.rs
@@ -2,6 +2,7 @@ use anyhow::anyhow;
 use fil_actors_runtime::runtime::Runtime;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::repr::{Deserialize_repr, Serialize_repr};
+use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use primitives::{TAmt, TCid};
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
@@ -30,6 +31,10 @@ pub struct Subnet {
     pub status: Status,
     pub prev_checkpoint: Option<BottomUpCheckpoint>,
     pub applied_bottomup_nonce: u64,
+    // genesis_epoch determines the epoch from which the subnet
+    // was registered. This signals the epoch from which
+    // the top-down checkpoint can be started.
+    pub genesis_epoch: ChainEpoch,
 }
 
 impl Subnet {

--- a/gateway/src/subnet.rs
+++ b/gateway/src/subnet.rs
@@ -29,6 +29,7 @@ pub struct Subnet {
     pub circ_supply: TokenAmount,
     pub status: Status,
     pub prev_checkpoint: Option<BottomUpCheckpoint>,
+    pub applied_bottomup_nonce: u64,
 }
 
 impl Subnet {
@@ -42,6 +43,17 @@ impl Subnet {
         if self.stake < st.min_stake {
             self.status = Status::Inactive;
         }
+        st.flush_subnet(rt.store(), self)?;
+        Ok(())
+    }
+
+    /// Increase the applied bottom-up nonce after an execution.
+    pub(crate) fn increase_applied_bottomup(
+        &mut self,
+        rt: &mut impl Runtime,
+        st: &mut State,
+    ) -> anyhow::Result<()> {
+        self.applied_bottomup_nonce += 1;
         st.flush_subnet(rt.store(), self)?;
         Ok(())
     }

--- a/gateway/src/types.rs
+++ b/gateway/src/types.rs
@@ -36,7 +36,6 @@ pub struct ConstructorParams {
     pub network_name: String,
     pub bottomup_check_period: ChainEpoch,
     pub topdown_check_period: ChainEpoch,
-    pub genesis_epoch: ChainEpoch,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
@@ -59,6 +58,11 @@ pub struct ApplyMsgParams {
 pub struct PropagateParams {
     /// The postbox message cid
     pub postbox_cid: Cid,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+pub struct InitGenesisEpoch {
+    pub genesis_epoch: ChainEpoch,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
@@ -124,7 +128,6 @@ mod tests {
             network_name: "/root".to_string(),
             bottomup_check_period: 100,
             topdown_check_period: 20,
-            genesis_epoch: 10,
         };
         let bytes = fil_actors_runtime::util::cbor::serialize(&p, "").unwrap();
         let serialized = base64::encode(bytes.bytes());
@@ -137,6 +140,5 @@ mod tests {
         assert_eq!(p.network_name, deserialized.network_name);
         assert_eq!(p.bottomup_check_period, deserialized.bottomup_check_period);
         assert_eq!(p.topdown_check_period, deserialized.topdown_check_period);
-        assert_eq!(p.genesis_epoch, deserialized.genesis_epoch);
     }
 }

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -273,6 +273,9 @@ fn checkpoint_commit() {
     let child_check = has_childcheck_source(&commit.data.children, &shid).unwrap();
     assert_eq!(&child_check.checks.len(), &1);
     assert_eq!(has_cid(&child_check.checks, &ch.cid()), true);
+    // check that the checkpoint was committed successfully in the subnet as previous checkpoint.
+    let subnet = h.get_subnet(&rt, &shid).unwrap();
+    assert_eq!(subnet.prev_checkpoint.unwrap(), ch);
 
     // Commit a checkpoint for subnet twice
     h.commit_child_check(&mut rt, &shid, &ch, ExitCode::USR_ILLEGAL_ARGUMENT)
@@ -326,6 +329,9 @@ fn checkpoint_commit() {
     let child_check = has_childcheck_source(&commit.data.children, &shid_two).unwrap();
     assert_eq!(&child_check.checks.len(), &1);
     assert_eq!(has_cid(&child_check.checks, &ch.cid()), true);
+    // check that the checkpoint was committed successfully in the subnet as previous checkpoint.
+    let subnet = h.get_subnet(&rt, &shid_two).unwrap();
+    assert_eq!(subnet.prev_checkpoint.unwrap(), ch);
 }
 
 #[test]
@@ -392,6 +398,9 @@ fn checkpoint_crossmsgs() {
     assert_eq!(&child_check.checks.len(), &1);
     let prev_cid = ch.cid();
     assert_eq!(has_cid(&child_check.checks, &prev_cid), true);
+    // check that the checkpoint was committed successfully in the subnet as previous checkpoint.
+    let subnet = h.get_subnet(&rt, &shid).unwrap();
+    assert_eq!(subnet.prev_checkpoint.unwrap(), ch);
 
     // TODO: More extensive tests?
 }

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -29,14 +29,12 @@ use ipc_gateway::{
     StorableMsg, Subnet, SubnetID, TopDownCheckpoint, CROSS_MSG_FEE, DEFAULT_CHECKPOINT_PERIOD,
     MIN_COLLATERAL_AMOUNT, SUBNET_ACTOR_REWARD_METHOD,
 };
+use ipc_sdk::subnet_id::ROOTNET_ID;
 use ipc_sdk::ValidatorSet;
 use lazy_static::lazy_static;
 use primitives::{TCid, TCidContent};
-use std::str::FromStr;
 
 lazy_static! {
-    pub static ref ROOTNET_ID: SubnetID =
-        SubnetID::new_from_parent(&SubnetID::from_str("/root").unwrap(), Address::new_id(0));
     pub static ref SUBNET_ONE: Address = Address::new_id(101);
     pub static ref SUBNET_TWO: Address = Address::new_id(102);
     pub static ref SUBNET_THR: Address = Address::new_id(103);
@@ -67,9 +65,13 @@ pub fn setup_root() -> (Harness, MockRuntime) {
 
 pub fn setup(id: SubnetID) -> (Harness, MockRuntime) {
     let mut rt = new_runtime();
-    let h = new_harness(id);
+    let h = new_harness(id.clone());
     h.construct(&mut rt);
-    h.initialize(&mut rt);
+    // the rootnet doesn't need to be explicitly
+    // initialized.
+    if id != *ROOTNET_ID {
+        h.initialize(&mut rt);
+    }
     (h, rt)
 }
 
@@ -127,7 +129,11 @@ impl Harness {
         );
         assert_eq!(
             st.topdown_checkpoint_voting.genesis_epoch(),
-            *DEFAULT_GENESIS_EPOCH
+            if st.network_name == *ROOTNET_ID {
+                0
+            } else {
+                *DEFAULT_GENESIS_EPOCH
+            }
         );
         verify_empty_map(rt, st.subnets.cid());
         verify_empty_map(rt, st.bottomup_checkpoints.cid());

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -102,7 +102,6 @@ impl Harness {
         assert_eq!(st.network_name, self.net_name);
         assert_eq!(st.min_stake, TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT));
         assert_eq!(st.bottomup_check_period, DEFAULT_CHECKPOINT_PERIOD);
-        assert_eq!(st.applied_bottomup_nonce, 0);
         assert_eq!(
             st.topdown_checkpoint_voting.submission_period(),
             *DEFAULT_TOPDOWN_PERIOD

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -25,9 +25,9 @@ use fvm_shared::METHOD_SEND;
 use ipc_gateway::checkpoint::ChildCheck;
 use ipc_gateway::{
     get_topdown_msg, is_bottomup, Actor, BottomUpCheckpoint, ConstructorParams, CrossMsg,
-    CrossMsgParams, FundParams, IPCAddress, Method, PropagateParams, State, StorableMsg, Subnet,
-    SubnetID, TopDownCheckpoint, CROSS_MSG_FEE, DEFAULT_CHECKPOINT_PERIOD, MIN_COLLATERAL_AMOUNT,
-    SUBNET_ACTOR_REWARD_METHOD,
+    CrossMsgParams, FundParams, IPCAddress, InitGenesisEpoch, Method, PropagateParams, State,
+    StorableMsg, Subnet, SubnetID, TopDownCheckpoint, CROSS_MSG_FEE, DEFAULT_CHECKPOINT_PERIOD,
+    MIN_COLLATERAL_AMOUNT, SUBNET_ACTOR_REWARD_METHOD,
 };
 use ipc_sdk::ValidatorSet;
 use lazy_static::lazy_static;
@@ -69,6 +69,7 @@ pub fn setup(id: SubnetID) -> (Harness, MockRuntime) {
     let mut rt = new_runtime();
     let h = new_harness(id);
     h.construct(&mut rt);
+    h.initialize(&mut rt);
     (h, rt)
 }
 
@@ -84,7 +85,6 @@ impl Harness {
             network_name: self.net_name.to_string(),
             bottomup_check_period: 10,
             topdown_check_period: *DEFAULT_TOPDOWN_PERIOD,
-            genesis_epoch: *DEFAULT_GENESIS_EPOCH,
         };
         rt.set_caller(*INIT_ACTOR_CODE_ID, INIT_ACTOR_ADDR);
         rt.call::<Actor>(
@@ -92,6 +92,25 @@ impl Harness {
             IpldBlock::serialize_cbor(&params).unwrap(),
         )
         .unwrap();
+    }
+
+    pub fn initialize(&self, rt: &mut MockRuntime) {
+        rt.expect_validate_caller_addr(vec![SYSTEM_ACTOR_ADDR]);
+        let params = InitGenesisEpoch {
+            genesis_epoch: *DEFAULT_GENESIS_EPOCH,
+        };
+        rt.set_caller(*SYSTEM_ACTOR_CODE_ID, SYSTEM_ACTOR_ADDR);
+        rt.call::<Actor>(
+            Method::InitGenesisEpoch as MethodNum,
+            IpldBlock::serialize_cbor(&params).unwrap(),
+        )
+        .unwrap();
+        let st: State = rt.get_state();
+        assert_eq!(st.initialized, true);
+        assert_eq!(
+            st.topdown_checkpoint_voting.genesis_epoch,
+            DEFAULT_GENESIS_EPOCH.clone()
+        );
     }
 
     pub fn construct_and_verify(&self, rt: &mut MockRuntime) {

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -50,7 +50,6 @@ pub struct State {
     // duplicated definition for easier data access in client applications
     pub bottomup_check_period: ChainEpoch,
     pub topdown_check_period: ChainEpoch,
-    pub genesis_epoch: ChainEpoch,
 
     // FIXME: Consider making checkpoints a HAMT instead of an AMT so we use
     // the AMT index instead of and epoch k for object indexing.
@@ -100,9 +99,6 @@ impl State {
             status: Status::Instantiated,
             stake: TCid::new_hamt(store)?,
             validator_set: ValidatorSet::default(),
-            // genesis epoch determines the epoch from the parent when the
-            // subnet was spawned.
-            genesis_epoch: current_epoch,
             previous_executed_checkpoint_cid: *CHECKPOINT_GENESIS_CID,
             bottomup_checkpoint_voting: Voting::<BottomUpCheckpoint>::new_with_ratio(
                 store,
@@ -357,7 +353,6 @@ impl Default for State {
             stake: TCid::default(),
             validator_set: ValidatorSet::default(),
             min_validators: 0,
-            genesis_epoch: 0,
             previous_executed_checkpoint_cid: *CHECKPOINT_GENESIS_CID,
             bottomup_checkpoint_voting: Voting {
                 genesis_epoch: 0,

--- a/subnet-actor/tests/actor_test.rs
+++ b/subnet-actor/tests/actor_test.rs
@@ -95,7 +95,6 @@ mod test {
         assert_eq!(state.ipc_gateway_addr, Address::new_id(IPC_GATEWAY_ADDR));
         assert_eq!(state.total_stake, TokenAmount::zero());
         assert_eq!(state.validator_set.validators().is_empty(), true);
-        assert_eq!(state.genesis_epoch, DEFAULT_GENESIS_EPOCH);
     }
 
     #[test]


### PR DESCRIPTION
## Background
Top-down checkpoints can't be sent from `0` they need to be sent from the moment the subnet was initialized because if not there's no way to get the subnet actor and the subnet information. When a subnet is registered in the gateway of the parent, its `genesis_epoch` is set. The issue is that this information lives in the parent, and when the subnet network is successfully deployed, it needs to know its genesis epoch in order to initialize the top-down voting.

## Implementation
Setting this `genesis_epoch` in genesis can be tricky, as we want the generation of genesis files to be deterministic for subnets, and it is not easy to trigger some kind of external callback to generate the genesis. So we went with the following approach:
- Subnets are spawned uninitialized, which means that their genesis epoch is zero and they can't commit any kind of checkpoint (bottom-up or top-down). 
- In the first block of the subnet, an implicit message is sent to a new method (included in this PR) called `InitGenesisEpoch` that initializes the subnet and signals the communicates the genesis epoch to the subnet. This signals the successful initialization of the subnet, and from there on, the subnet can start operating normally.