### PR TITLE
fix UniqueBytesKey serialization

### DIFF
--- a/common/src/vote/mod.rs
+++ b/common/src/vote/mod.rs
@@ -18,10 +18,6 @@ pub trait UniqueVote: PartialEq + Clone {
 pub struct UniqueBytesKey(pub Vec<u8>);
 
 impl UniqueBytesKey {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
     pub fn as_slice(&self) -> &[u8] {
         self.0.as_slice()
     }
@@ -29,6 +25,12 @@ impl UniqueBytesKey {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+}
+
+impl Default for UniqueBytesKey {
+  fn default() -> Self {
+     Self(Vec::new())
+ }
 }
 
 impl PartialEq<Vec<u8>> for UniqueBytesKey {

--- a/common/src/vote/mod.rs
+++ b/common/src/vote/mod.rs
@@ -14,7 +14,7 @@ pub trait UniqueVote: PartialEq + Clone {
 }
 
 // pub type UniqueBytesKey = Vec<u8>;
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Default)]
 pub struct UniqueBytesKey(pub Vec<u8>);
 
 impl UniqueBytesKey {
@@ -25,12 +25,6 @@ impl UniqueBytesKey {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
-}
-
-impl Default for UniqueBytesKey {
-  fn default() -> Self {
-     Self(Vec::new())
- }
 }
 
 impl PartialEq<Vec<u8>> for UniqueBytesKey {

--- a/common/src/vote/mod.rs
+++ b/common/src/vote/mod.rs
@@ -1,14 +1,11 @@
-
 mod submission;
 mod voting;
 
-
-use fvm_ipld_encoding::{serde_bytes};
+use fvm_ipld_encoding::serde_bytes;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use crate::vote::submission::EpochVoteSubmissions;
 pub use crate::vote::voting::Voting;
-
 
 /// The vote trait that requires each vote to be unique by `unique_key`.
 pub trait UniqueVote: PartialEq + Clone {
@@ -25,13 +22,13 @@ impl UniqueBytesKey {
         Self(Vec::new())
     }
 
-    pub fn as_slice(&self) -> &[u8]{
+    pub fn as_slice(&self) -> &[u8] {
         self.0.as_slice()
-    }   
+    }
 
-    pub fn is_empty(&self) -> bool{
+    pub fn is_empty(&self) -> bool {
         self.0.is_empty()
-    }   
+    }
 }
 
 impl PartialEq<Vec<u8>> for UniqueBytesKey {

--- a/common/src/vote/mod.rs
+++ b/common/src/vote/mod.rs
@@ -1,13 +1,66 @@
+
 mod submission;
 mod voting;
+
+
+use fvm_ipld_encoding::{serde_bytes};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use crate::vote::submission::EpochVoteSubmissions;
 pub use crate::vote::voting::Voting;
 
-pub type UniqueBytesKey = Vec<u8>;
 
 /// The vote trait that requires each vote to be unique by `unique_key`.
 pub trait UniqueVote: PartialEq + Clone {
     /// Outputs the unique bytes key of the vote
     fn unique_key(&self) -> anyhow::Result<UniqueBytesKey>;
+}
+
+// pub type UniqueBytesKey = Vec<u8>;
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct UniqueBytesKey(pub Vec<u8>);
+
+impl UniqueBytesKey {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn as_slice(&self) -> &[u8]{
+        self.0.as_slice()
+    }   
+
+    pub fn is_empty(&self) -> bool{
+        self.0.is_empty()
+    }   
+}
+
+impl PartialEq<Vec<u8>> for UniqueBytesKey {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.0.as_slice() == other.as_slice()
+    }
+}
+
+impl PartialEq<UniqueBytesKey> for Vec<u8> {
+    fn eq(&self, other: &UniqueBytesKey) -> bool {
+        self.as_slice() == other.0.as_slice()
+    }
+}
+
+impl Serialize for UniqueBytesKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serde_bytes::serialize(&self.0, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for UniqueBytesKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes: Vec<u8> = serde_bytes::deserialize(deserializer)?;
+        Ok(UniqueBytesKey(bytes))
+    }
 }

--- a/common/src/vote/submission.rs
+++ b/common/src/vote/submission.rs
@@ -310,7 +310,7 @@ impl<T: Serialize> Serialize for EpochVoteSubmissions<T> {
         } else {
             let inner = (
                 &self.total_submission_weight,
-                &UniqueBytesKey::new(),
+                &UniqueBytesKey::default(),
                 &self.submitters,
                 &self.submission_weights,
                 &self.submissions,
@@ -406,7 +406,7 @@ mod tests {
 
         let dummy_submissions = DummySubmissions {
             total_submission_weight: TokenAmount::from_atto(100),
-            most_voted_key: UniqueBytesKey::new(),
+            most_voted_key: UniqueBytesKey::default(),
             submitters: Default::default(),
             submission_weights: Default::default(),
             submissions: Default::default(),

--- a/common/src/vote/submission.rs
+++ b/common/src/vote/submission.rs
@@ -386,7 +386,7 @@ mod tests {
 
         let dummy_submissions = DummySubmissions {
             total_submission_weight: TokenAmount::from_atto(100),
-            most_voted_key: vec![1, 2, 3],
+            most_voted_key: UniqueBytesKey(vec![1, 2, 3]),
             submitters: Default::default(),
             submission_weights: Default::default(),
             submissions: Default::default(),
@@ -394,7 +394,7 @@ mod tests {
 
         let submissions = EpochVoteSubmissions::<DummyVote> {
             total_submission_weight: TokenAmount::from_atto(100),
-            most_voted_key: Some(vec![1, 2, 3]),
+            most_voted_key: Some(UniqueBytesKey(vec![1, 2, 3])),
             submitters: Default::default(),
             submission_weights: Default::default(),
             submissions: Default::default(),
@@ -406,7 +406,7 @@ mod tests {
 
         let dummy_submissions = DummySubmissions {
             total_submission_weight: TokenAmount::from_atto(100),
-            most_voted_key: vec![],
+            most_voted_key: UniqueBytesKey::new(),
             submitters: Default::default(),
             submission_weights: Default::default(),
             submissions: Default::default(),
@@ -432,7 +432,7 @@ mod tests {
 
         let submissions = EpochVoteSubmissions::<DummyVote> {
             total_submission_weight: TokenAmount::from_atto(100),
-            most_voted_key: Some(vec![1, 2, 3, 4]),
+            most_voted_key: Some(UniqueBytesKey(vec![1, 2, 3, 4])),
             submitters: Default::default(),
             submission_weights: Default::default(),
             submissions: Default::default(),
@@ -476,7 +476,7 @@ mod tests {
         let store = MemoryBlockstore::new();
         let mut submission = EpochVoteSubmissions::<DummyVote>::new(&store).unwrap();
 
-        let checkpoint = DummyVote { key: vec![0] };
+        let checkpoint = DummyVote { key: UniqueBytesKey(vec![0]) };
 
         let hash = checkpoint.unique_key().unwrap();
 
@@ -495,8 +495,8 @@ mod tests {
         let store = MemoryBlockstore::new();
         let mut submission = EpochVoteSubmissions::<DummyVote>::new(&store).unwrap();
 
-        let hash1 = vec![1, 2, 1];
-        let hash2 = vec![1, 2, 2];
+        let hash1 = UniqueBytesKey(vec![1, 2, 1]);
+        let hash2 = UniqueBytesKey(vec![1, 2, 2]);
 
         // insert hash1, should have only one item
         assert_eq!(submission.most_voted_key, None);

--- a/common/src/vote/submission.rs
+++ b/common/src/vote/submission.rs
@@ -476,7 +476,9 @@ mod tests {
         let store = MemoryBlockstore::new();
         let mut submission = EpochVoteSubmissions::<DummyVote>::new(&store).unwrap();
 
-        let checkpoint = DummyVote { key: UniqueBytesKey(vec![0]) };
+        let checkpoint = DummyVote {
+            key: UniqueBytesKey(vec![0]),
+        };
 
         let hash = checkpoint.unique_key().unwrap();
 

--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -35,7 +35,7 @@ pub struct BottomUpCheckpoint {
 
 impl UniqueVote for BottomUpCheckpoint {
     fn unique_key(&self) -> anyhow::Result<UniqueBytesKey> {
-        Ok(self.cid().to_bytes())
+        Ok(UniqueBytesKey(self.cid().to_bytes()))
     }
 }
 
@@ -280,7 +280,7 @@ impl UniqueVote for TopDownCheckpoint {
         // TODO: to avoid serialization again, maybe we should perform deserialization in the actor
         // TODO: dispatch call to save gas? The actor dispatching contains the raw serialized data,
         // TODO: which we dont have to serialize here again
-        Ok(mh_code.digest(&to_vec(self).unwrap()).to_bytes())
+        Ok(UniqueBytesKey(mh_code.digest(&to_vec(self).unwrap()).to_bytes()))
     }
 }
 

--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -280,7 +280,9 @@ impl UniqueVote for TopDownCheckpoint {
         // TODO: to avoid serialization again, maybe we should perform deserialization in the actor
         // TODO: dispatch call to save gas? The actor dispatching contains the raw serialized data,
         // TODO: which we dont have to serialize here again
-        Ok(UniqueBytesKey(mh_code.digest(&to_vec(self).unwrap()).to_bytes()))
+        Ok(UniqueBytesKey(
+            mh_code.digest(&to_vec(self).unwrap()).to_bytes(),
+        ))
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/consensus-shipyard/ipc-actors/issues/97

It wraps `UniqueKeyBytes` as a tuple so it can be serialized as `serde_bytes` and the right type is CBOR serialized.