### PR TITLE
add pre-fund when there are less than three validators

### DIFF
--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -690,11 +690,17 @@ impl Actor {
             // Get validators that are different from the existing validator set
             let mut pre_fund = vec![];
             for v in validator_set.validators().iter() {
-                if !st.validators.validators.validators().iter().any(|x| x.addr == v.addr) {
+                if !st
+                    .validators
+                    .validators
+                    .validators()
+                    .iter()
+                    .any(|x| x.addr == v.addr)
+                {
                     pre_fund.push(v.addr.clone());
                 }
             }
-                
+
             Ok((st.network_name.clone(), pre_fund))
         })?;
 
@@ -707,24 +713,23 @@ impl Actor {
         // to be committed. This doesn't apply to the root.
         // TODO: Once account abstraction is conveniently supported, there will be
         // no need for this initial funding of validators.
-        if  network_name != *ROOTNET_ID {
+        if network_name != *ROOTNET_ID {
             if rt.curr_epoch() == 1 {
-            for v in validator_set.validators().iter() {
-                rt.send(&v.addr, METHOD_SEND, None, INITIAL_VALIDATOR_FUNDS.clone())?;
+                for v in validator_set.validators().iter() {
+                    rt.send(&v.addr, METHOD_SEND, None, INITIAL_VALIDATOR_FUNDS.clone())?;
+                }
+            }
+
+            // to prevent top-down checkpoint submissions from being stuck when the number of validators
+            // is too small (< 3), where if a new validator join and it doesn't have funds
+            // no new top-down checkpoints can be submitted, we add some balance also for
+            // non-initial validators.
+            if rt.curr_epoch() > 1 && validator_set.validators().len() < 4 {
+                for v in pre_fund.iter() {
+                    rt.send(&v, METHOD_SEND, None, INITIAL_VALIDATOR_FUNDS.clone())?;
+                }
             }
         }
-
-        // to prevent top-down checkpoint submissions from being stuck when the number of validators
-        // is too small (< 3), where if a new validator join and it doesn't have funds
-        // no new top-down checkpoints can be submitted, we add some balance also for
-        // non-initial validators.
-        if rt.curr_epoch() > 1 && validator_set.validators().len() < 4 {
-            for v in pre_fund.iter() {
-                rt.send(&v, METHOD_SEND, None, INITIAL_VALIDATOR_FUNDS.clone())?;
-            }
-        }
-    }
-
 
         Ok(RawBytes::default())
     }

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -697,7 +697,7 @@ impl Actor {
                     .iter()
                     .any(|x| x.addr == v.addr)
                 {
-                    pre_fund.push(v.addr.clone());
+                    pre_fund.push(v.addr);
                 }
             }
 
@@ -726,7 +726,7 @@ impl Actor {
             // non-initial validators.
             if rt.curr_epoch() > 1 && validator_set.validators().len() < 4 {
                 for v in pre_fund.iter() {
-                    rt.send(&v, METHOD_SEND, None, INITIAL_VALIDATOR_FUNDS.clone())?;
+                    rt.send(v, METHOD_SEND, None, INITIAL_VALIDATOR_FUNDS.clone())?;
                 }
             }
         }


### PR DESCRIPTION
## Background
In order to remove the chicken-and-egg problem described in https://github.com/consensus-shipyard/ipc-actors/pull/96 we send some initial funds to the initial validators in a subnet. The issue is that if we spawn a subnet with just one validator, and we join from another validator, the second validator won't have any funds to submit top-down checkpoints, and as a super-majority is required to commit the checkpoint, there won't be any way for the joining validator to inject funds in the subnet to submit top-down checkpoints, stalling the checkpoint submission of top-down checkpoints for the subnet.

## Proposal
For now, this PR introduces a work-around where some initial funds are also sent to joining validators when the number of validators is below `3`, to prevent joining validators from not being able to submit a checkpoint for lack of funds. A more robust solution should be considered like using [account abstraction](https://github.com/consensus-shipyard/ipc-actors/issues/91) or some kind of checkpoint submission subsidising system.