### PR TITLE
Refactor SubnetID and add ChainID to root

### DIFF
--- a/atomic-exec/examples/fungible-token/src/tests.rs
+++ b/atomic-exec/examples/fungible-token/src/tests.rs
@@ -14,9 +14,12 @@ use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, MethodNum
 use ipc_atomic_execution::AtomicExecID;
 use ipc_atomic_execution_primitives::{AtomicExecRegistry, AtomicInputID};
 use ipc_gateway::{CrossMsg, IPCAddress, StorableMsg, SubnetID};
-use ipc_sdk::subnet_id::ROOTNET_ID;
 use num_traits::Zero;
 use std::collections::HashMap;
+
+lazy_static::lazy_static! {
+    static ref ROOTNET_ID: SubnetID = SubnetID::new(123, vec![]);
+}
 
 #[test]
 fn test_constructor() {

--- a/atomic-exec/src/state.rs
+++ b/atomic-exec/src/state.rs
@@ -83,7 +83,10 @@ mod tests {
     use super::*;
     use fvm_ipld_blockstore::MemoryBlockstore;
     use ipc_gateway::{IPCAddress, SubnetID};
-    use ipc_sdk::subnet_id::ROOTNET_ID;
+
+    lazy_static::lazy_static! {
+        static ref ROOTNET_ID: SubnetID = SubnetID::new(123, vec![]);
+    }
 
     #[test]
     fn state_works() {

--- a/atomic-exec/tests/actor_test.rs
+++ b/atomic-exec/tests/actor_test.rs
@@ -7,7 +7,6 @@ use fvm_ipld_encoding::{ipld_block::IpldBlock, RawBytes};
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, MethodNum};
 use ipc_atomic_execution::{Actor, AtomicExecID, ConstructorParams, Method, PreCommitParams};
 use ipc_gateway::{ApplyMsgParams, CrossMsg, IPCAddress, StorableMsg, SubnetID};
-use ipc_sdk::subnet_id::ROOTNET_ID;
 
 #[test]
 fn test_pre_commit_wrong_origin() {
@@ -81,12 +80,12 @@ lazy_static::lazy_static! {
         ipc_gateway_address: *IPC_GATEWAY_ADDR,
     };
 
-    static ref COORD_ACTOR: IPCAddress = IPCAddress::new(&ROOTNET_ID, &Address::new_id(1)).unwrap();
+    pub static ref ROOTNET_ID: SubnetID = SubnetID::new(123, vec![]);
 
+    static ref COORD_ACTOR: IPCAddress = IPCAddress::new(&ROOTNET_ID, &Address::new_id(1)).unwrap();
     static ref SUBNET_A: SubnetID = SubnetID::new_from_parent(&ROOTNET_ID, Address::new_id('A' as u64));
     static ref ACTOR_A1: IPCAddress = IPCAddress::new(&SUBNET_A, &Address::new_id(1)).unwrap();
     static ref ACTOR_A2: IPCAddress = IPCAddress::new(&SUBNET_A, &Address::new_id(2)).unwrap();
-
     static ref SUBNET_B: SubnetID = SubnetID::new_from_parent(&ROOTNET_ID, Address::new_id('B' as u64));
     static ref ACTOR_B1: IPCAddress = IPCAddress::new(&SUBNET_B, &Address::new_id(1)).unwrap();
     static ref ACTOR_B2: IPCAddress = IPCAddress::new(&SUBNET_B, &Address::new_id(2)).unwrap();

--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_serialization() {
-        let mut checkpoint = BottomUpCheckpoint::new(SubnetID::from_str("/root").unwrap(), 10);
+        let mut checkpoint = BottomUpCheckpoint::new(SubnetID::from_str("/r123").unwrap(), 10);
         checkpoint.data.prev_check = TCid::from(
             Cid::from_str("bafy2bzacecnamqgqmifpluoeldx7zzglxcljo6oja4vrmtj7432rphldpdmm2")
                 .unwrap(),

--- a/gateway/src/cross.rs
+++ b/gateway/src/cross.rs
@@ -14,7 +14,6 @@ use fvm_shared::METHOD_SEND;
 use ipc_sdk::address::IPCAddress;
 use ipc_sdk::subnet_id::SubnetID;
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
-use std::path::Path;
 
 /// StorableMsg stores all the relevant information required
 /// to execute cross-messages.
@@ -150,8 +149,8 @@ pub fn is_bottomup(from: &SubnetID, to: &SubnetID) -> bool {
         Some((ind, _)) => ind,
         None => return false,
     };
-    let a = from.to_string();
-    Path::new(&a).components().count() - 1 > index
+    // more children than the common parent
+    from.children_as_ref().len() > index
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, Default, Serialize_tuple, Deserialize_tuple)]
@@ -224,13 +223,14 @@ mod tests {
 
     #[test]
     fn test_is_bottomup() {
-        bottom_up("/root/t01", "/root/t01/t02", false);
-        bottom_up("/root/t01", "/root", true);
-        bottom_up("/root/t01", "/root/t01/t02", false);
-        bottom_up("/root/t01", "/root/t02/t02", true);
-        bottom_up("/root/t01/t02", "/root/t01/t02", false);
-        bottom_up("/root/t01/t02", "/root/t01/t02/t03", false);
+        bottom_up("/r123/f01", "/r123/f01/f02", false);
+        bottom_up("/r123/f01", "/r123", true);
+        bottom_up("/r123/f01", "/r123/f01/f02", false);
+        bottom_up("/r123/f01", "/r123/f02/f02", true);
+        bottom_up("/r123/f01/f02", "/r123/f01/f02", false);
+        bottom_up("/r123/f01/f02", "/r123/f01/f02/f03", false);
     }
+
     fn bottom_up(a: &str, b: &str, res: bool) {
         assert_eq!(
             is_bottomup(

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -24,7 +24,6 @@ use fvm_shared::METHOD_SEND;
 use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
 pub use ipc_sdk::address::IPCAddress;
 pub use ipc_sdk::subnet_id::SubnetID;
-use ipc_sdk::subnet_id::ROOTNET_ID;
 use ipc_sdk::ValidatorSet;
 use lazy_static::lazy_static;
 use num_derive::FromPrimitive;
@@ -84,7 +83,7 @@ impl Actor {
             )
         })?;
         // the root doesn't need to be explicitly initialized
-        if st.network_name == *ROOTNET_ID {
+        if st.network_name.is_root() {
             st.init_gateway(rt.store(), 0)?;
         }
         rt.create(&st)?;
@@ -700,7 +699,7 @@ impl Actor {
         // TODO: Once account abstraction is conveniently supported, there will be
         // no need for this initial funding of validators.
 
-        if rt.curr_epoch() == 1 && network_name != *ROOTNET_ID {
+        if rt.curr_epoch() == 1 && !network_name.is_root() {
             for v in validator_set.validators().iter() {
                 rt.send(&v.addr, METHOD_SEND, None, INITIAL_VALIDATOR_FUNDS.clone())?;
             }

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -16,7 +16,7 @@ use ipc_gateway::{
     get_topdown_msg, BottomUpCheckpoint, CrossMsg, IPCAddress, PostBoxItem, State, StorableMsg,
     TopDownCheckpoint, CROSS_MSG_FEE, INITIAL_VALIDATOR_FUNDS, SUBNET_ACTOR_REWARD_METHOD,
 };
-use ipc_sdk::subnet_id::{SubnetID, ROOTNET_ID};
+use ipc_sdk::subnet_id::SubnetID;
 use ipc_sdk::{epoch_key, Validator, ValidatorSet};
 use primitives::TCid;
 use std::collections::BTreeSet;
@@ -519,7 +519,7 @@ fn test_send_cross() {
         .unwrap();
 
     // top-down
-    let sub = SubnetID::from_str("/root/t0101/t0101").unwrap();
+    let sub = SubnetID::from_str("/r123/f0101/f0101").unwrap();
     h.send_cross(
         &mut rt,
         &from,
@@ -532,7 +532,7 @@ fn test_send_cross() {
         &value,
     )
     .unwrap();
-    let sub = SubnetID::from_str("/root/t0101/t0101").unwrap();
+    let sub = SubnetID::from_str("/r123/f0101/f0101").unwrap();
     let circ_sup = 2 * &value;
     h.send_cross(
         &mut rt,
@@ -546,7 +546,7 @@ fn test_send_cross() {
         &circ_sup,
     )
     .unwrap();
-    let sub = SubnetID::from_str("/root/t0101/t0101/t01002").unwrap();
+    let sub = SubnetID::from_str("/r123/f0101/f0101/f01002").unwrap();
     let circ_sup = circ_sup.clone() + &value;
     h.send_cross(
         &mut rt,
@@ -563,7 +563,7 @@ fn test_send_cross() {
 
     // bottom-up
     rt.set_balance(3 * &value);
-    let sub = SubnetID::from_str("/root/t0102/t0101").unwrap();
+    let sub = SubnetID::from_str("/r123/f0102/f0101").unwrap();
     let zero = TokenAmount::zero();
     h.send_cross(
         &mut rt,
@@ -577,7 +577,7 @@ fn test_send_cross() {
         &zero,
     )
     .unwrap();
-    let sub = SubnetID::from_str("/root/t0102/t0101").unwrap();
+    let sub = SubnetID::from_str("/r123/f0102/f0101").unwrap();
     h.send_cross(
         &mut rt,
         &from,
@@ -590,7 +590,7 @@ fn test_send_cross() {
         &zero,
     )
     .unwrap();
-    let sub = SubnetID::from_str("/root").unwrap();
+    let sub = SubnetID::from_str("/r123").unwrap();
     h.send_cross(
         &mut rt,
         &from,

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -29,7 +29,6 @@ use ipc_gateway::{
     StorableMsg, Subnet, SubnetID, TopDownCheckpoint, CROSS_MSG_FEE, DEFAULT_CHECKPOINT_PERIOD,
     MIN_COLLATERAL_AMOUNT, SUBNET_ACTOR_REWARD_METHOD,
 };
-use ipc_sdk::subnet_id::ROOTNET_ID;
 use ipc_sdk::ValidatorSet;
 use lazy_static::lazy_static;
 use primitives::{TCid, TCidContent};
@@ -44,6 +43,7 @@ lazy_static! {
     pub static ref SIG_TYPES: Vec<Cid> = vec![*ACCOUNT_ACTOR_CODE_ID, *MULTISIG_ACTOR_CODE_ID];
     pub static ref DEFAULT_TOPDOWN_PERIOD: ChainEpoch = 20;
     pub static ref DEFAULT_GENESIS_EPOCH: ChainEpoch = 1;
+    pub static ref ROOTNET_ID: SubnetID = SubnetID::new(123, vec![]);
 }
 
 pub fn new_runtime() -> MockRuntime {

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -18,6 +18,7 @@ num-traits = "0.2.14"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
 lazy_static = "1.4.0"
+fnv = "1.0.7"
 serde_tuple = "0.5"
 serde = { version = "1.0.136", features = ["derive"] }
 fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -70,15 +70,16 @@ impl FromStr for IPCAddress {
 #[cfg(test)]
 mod tests {
     use crate::address::IPCAddress;
-    use crate::subnet_id::{SubnetID, ROOTNET_ID};
+    use crate::subnet_id::SubnetID;
     use fvm_shared::address::Address;
     use std::str::FromStr;
+    use std::vec;
 
     #[test]
     fn test_ipc_address() {
         let act = Address::new_id(1001);
-        let sub_id = SubnetID::new_from_parent(&ROOTNET_ID.clone(), act);
-        let bls = Address::from_str("t3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a").unwrap();
+        let sub_id = SubnetID::new(123, vec![act]);
+        let bls = Address::from_str("f3vvmn62lofvhjd2ugzca6sof2j2ubwok6cj4xxbfzz4yuxfkgobpihhd2thlanmsh3w2ptld2gqkn2jvlss4a").unwrap();
         let haddr = IPCAddress::new(&sub_id, &bls).unwrap();
 
         let str = haddr.to_string().unwrap();
@@ -91,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_ipc_from_str() {
-        let sub_id = SubnetID::new_from_parent(&ROOTNET_ID.clone(), Address::new_id(100));
+        let sub_id = SubnetID::new(123, vec![Address::new_id(100)]);
         let addr = IPCAddress::new(&sub_id, &Address::new_id(101)).unwrap();
         let st = addr.to_string().unwrap();
         let addr_out = IPCAddress::from_str(&st).unwrap();
@@ -100,7 +101,7 @@ mod tests {
 
     #[test]
     fn test_ipc_serialization() {
-        let sub_id = SubnetID::new_from_parent(&ROOTNET_ID.clone(), Address::new_id(100));
+        let sub_id = SubnetID::new(123, vec![Address::new_id(100)]);
         let addr = IPCAddress::new(&sub_id, &Address::new_id(101)).unwrap();
         let st = addr.to_bytes().unwrap();
         let addr_out = IPCAddress::from_bytes(&st).unwrap();

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,29 +1,12 @@
 use fil_actors_runtime::fvm_ipld_hamt::BytesKey;
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
+use fvm_shared::clock::ChainEpoch;
 use fvm_shared::{address::Address, econ::TokenAmount};
-use fvm_shared::{
-    address::{set_current_network, Network},
-    clock::ChainEpoch,
-};
 use integer_encoding::VarInt;
-use num_traits::cast::FromPrimitive;
 
 pub mod address;
 pub mod error;
 pub mod subnet_id;
-
-/// Sets the type of network from an environmental variable.
-/// This is key to set the right network prefixes on string
-/// representation of addresses.
-pub fn set_network_from_env() {
-    let network_raw: u8 = std::env::var("LOTUS_NETWORK")
-        // default to testnet
-        .unwrap_or_else(|_| String::from("1"))
-        .parse()
-        .unwrap();
-    let network = Network::from_u8(network_raw).unwrap();
-    set_current_network(network);
-}
 
 /// Encodes the a ChainEpoch as a varInt for its use
 /// as a key of a HAMT. This serialization has been

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -69,8 +69,14 @@ impl SubnetID {
     }
 
     /// Returns the address of the actor governing the subnet in the parent
+    /// If there is no subnet actor it returns the address ID=0
     pub fn subnet_actor(&self) -> Address {
-        *self.children_as_ref().last().unwrap()
+        if let Some(addr) = self.children.last() {
+            *addr
+        } else {
+            // protect against the case that the children slice is empty
+            Address::new_id(0)
+        }
     }
 
     /// Returns the parenet of the current subnet

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -45,7 +45,7 @@ impl SubnetID {
 
     /// Returns true if the current subnet is the root network
     pub fn is_root(&self) -> bool {
-        self.children_as_ref().len() == 0
+        self.children_as_ref().is_empty()
     }
 
     /// Returns the chainID of the root network.
@@ -70,13 +70,13 @@ impl SubnetID {
 
     /// Returns the address of the actor governing the subnet in the parent
     pub fn subnet_actor(&self) -> Address {
-        self.children_as_ref().last().unwrap().clone()
+        *self.children_as_ref().last().unwrap()
     }
 
     /// Returns the parenet of the current subnet
     pub fn parent(&self) -> Option<SubnetID> {
         // if the subnet is the root, it has no parent
-        if self.children_as_ref().len() == 0 {
+        if self.children_as_ref().is_empty() {
             return None;
         }
 

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -227,7 +227,7 @@ mod tests {
         let act = Address::new_id(1001);
         let sub_id = SubnetID::new(123, vec![act]);
         let chain_id = sub_id.chain_id();
-        assert_eq!(chain_id, 2185257692569594473);
+        assert_eq!(chain_id, 1011873294913613);
 
         let root = sub_id.parent().unwrap();
         let chain_id = root.chain_id();

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -2,12 +2,17 @@ use fil_actors_runtime::cbor;
 use fvm_shared::address::Address;
 use lazy_static::lazy_static;
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+use std::collections::hash_map::DefaultHasher;
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
 use crate::error::Error;
 
 const SUBNET_ERR_TAG: &str = "subnetID";
+/// MaxChainID is the maximum chain ID value
+/// possible.
+const MAX_CHAIN_ID: u64 = 0xffffffffffffffff;
 
 /// SubnetID is a unique identifier for a subnet.
 /// It is composed of the chainID of the root network, and the address of
@@ -51,6 +56,13 @@ impl SubnetID {
     /// Returns the chainID of the root network.
     pub fn root_id(&self) -> u64 {
         self.root
+    }
+
+    /// Returns the chainID of the current subnet
+    pub fn chain_id(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.to_bytes().hash(&mut hasher);
+        hasher.finish() % MAX_CHAIN_ID
     }
 
     /// Returns the route from the root to the current subnet

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -11,8 +11,9 @@ use crate::error::Error;
 
 const SUBNET_ERR_TAG: &str = "subnetID";
 /// MaxChainID is the maximum chain ID value
-/// possible.
-const MAX_CHAIN_ID: u64 = 0xffffffffffffffff;
+/// possible. This is the MAX_CHAIN_ID currently
+/// supported by Ethereum chains.
+pub const MAX_CHAIN_ID: u64 = 4503599627370476;
 
 /// SubnetID is a unique identifier for a subnet.
 /// It is composed of the chainID of the root network, and the address of

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -48,6 +48,14 @@ impl SubnetID {
         }
     }
 
+    /// Creates a new rootnet SubnetID
+    pub fn new_root(root_id: u64) -> Self {
+        Self {
+            root: root_id,
+            children: vec![],
+        }
+    }
+
     /// Returns true if the current subnet is the root network
     pub fn is_root(&self) -> bool {
         self.children_as_ref().is_empty()

--- a/subnet-actor/tests/actor_test.rs
+++ b/subnet-actor/tests/actor_test.rs
@@ -33,13 +33,14 @@ mod test {
     const IPC_GATEWAY_ADDR: u64 = 1024;
     const NETWORK_NAME: &'static str = "test";
     const DEFAULT_GENESIS_EPOCH: ChainEpoch = 0;
+    const ROOT_STR_ID: &str = "/r123";
 
     lazy_static! {
         pub static ref SIG_TYPES: Vec<Cid> = vec![*ACCOUNT_ACTOR_CODE_ID, *MULTISIG_ACTOR_CODE_ID];
     }
     fn std_construct_param() -> ConstructParams {
         ConstructParams {
-            parent: SubnetID::from_str("/root").unwrap(),
+            parent: SubnetID::from_str(ROOT_STR_ID).unwrap(),
             name: NETWORK_NAME.to_string(),
             ipc_gateway_addr: IPC_GATEWAY_ADDR,
             consensus: ConsensusType::Dummy,
@@ -703,7 +704,7 @@ mod test {
         assert_eq!(st.status, Status::Active);
 
         // Generate the check point
-        let root_subnet = SubnetID::from_str("/root").unwrap();
+        let root_subnet = SubnetID::from_str(ROOT_STR_ID).unwrap();
         let subnet = SubnetID::new_from_parent(&root_subnet, test_actor_address);
         // we are targeting the next submission period
         let epoch = DEFAULT_GENESIS_EPOCH + st.bottomup_checkpoint_voting.submission_period;
@@ -854,7 +855,7 @@ mod test {
         let st: State = runtime.get_state();
 
         // Generate the check point
-        let root_subnet = SubnetID::from_str("/root").unwrap();
+        let root_subnet = SubnetID::from_str(ROOT_STR_ID).unwrap();
         let subnet = SubnetID::new_from_parent(&root_subnet, test_actor_address);
         // we are targeting the next submission period
         let epoch = DEFAULT_GENESIS_EPOCH + st.bottomup_checkpoint_voting.submission_period;
@@ -963,7 +964,7 @@ mod test {
             i += 1;
         }
 
-        let root_subnet = SubnetID::from_str("/root").unwrap();
+        let root_subnet = SubnetID::from_str(ROOT_STR_ID).unwrap();
         let subnet = SubnetID::new_from_parent(&root_subnet, test_actor_address);
 
         // Step 2


### PR DESCRIPTION
Addresses https://github.com/consensus-shipyard/ipc-actors/issues/78

Our previous implementation of `SubnetID` had two main issues: 
- As we used strings to internal represent the parent of a subnet, it was dependent of the network type prefix `t/f` which meant that setting a different network type in Lotus and the actors led to really annoying panics/errors.
- We didn't have a way to discern among different IPC trees. For this, instead of using `root` to identify the root of an IPC hierarchy, we use the `ChainID` to "uniquely" identify different IPC trees.

Finally, we've decided that instead of supporting Ethereum addressed for subnet actors, these will be included in the path of a `SubnetID` through their corresponding `f4` address (thus supporting any future alternative addressing that comes to the network). 

## Next 
- [x] Propagate the changes to the Golang implementation: https://github.com/consensus-shipyard/go-ipc-types/pull/21
- [x] Integrate in Lotus/Eudico: https://github.com/consensus-shipyard/lotus/pull/187
- [x] https://github.com/consensus-shipyard/lotus/issues/178
- [x] https://github.com/consensus-shipyard/ipc-agent/issues/214