### PR TITLE
support robust address for SubnetID

### DIFF
--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -96,6 +96,14 @@ impl BottomUpCheckpoint {
         }
     }
 
+    /// Agents may set the source of a checkpoint using f2-based subnetIDs, \
+    /// but actors are expected to use f0-based subnetIDs, thus the need to enforce
+    /// that the source is a f0-based subnetID.
+    pub fn enforce_f0_source(&mut self, rt: &mut impl Runtime) -> anyhow::Result<()> {
+        self.data.source = self.source().f0_id(rt);
+        Ok(())
+    }
+
     /// Get the sum of values in cross messages
     pub fn total_value(&self) -> TokenAmount {
         match &self.data.cross_msgs.cross_msgs {

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -99,7 +99,7 @@ impl Actor {
         let mut shid = SubnetID::default();
         rt.transaction(|st: &mut State, rt| {
             shid = SubnetID::new_from_parent(&st.network_name, subnet_addr);
-            let sub = st.get_subnet(rt, rt.store(), &shid).map_err(|e| {
+            let sub = st.get_subnet(rt, &shid).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load subnet")
             })?;
             match sub {
@@ -140,7 +140,7 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             let shid = SubnetID::new_from_parent(&st.network_name, subnet_addr);
-            let sub = st.get_subnet(rt, rt.store(), &shid).map_err(|e| {
+            let sub = st.get_subnet(rt, &shid).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load subnet")
             })?;
             match sub {
@@ -184,7 +184,7 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             let shid = SubnetID::new_from_parent(&st.network_name, subnet_addr);
-            let sub = st.get_subnet(rt,rt.store(), &shid).map_err(|e| {
+            let sub = st.get_subnet(rt, &shid).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load subnet")
             })?;
             match sub {
@@ -235,7 +235,7 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             let shid = SubnetID::new_from_parent(&st.network_name, subnet_addr);
-            let sub = st.get_subnet(rt,rt.store(), &shid).map_err(|e| {
+            let sub = st.get_subnet(rt, &shid).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load subnet")
             })?;
             match sub {
@@ -303,7 +303,7 @@ impl Actor {
             st.require_initialized()?;
 
             let shid = SubnetID::new_from_parent(&st.network_name, subnet_addr);
-            let sub = st.get_subnet(rt, rt.store(), &shid).map_err(|e| {
+            let sub = st.get_subnet(rt, &shid).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load subnet")
             })?;
 
@@ -922,7 +922,7 @@ impl Actor {
                 if sto == st.network_name {
                     rt.transaction(|st: &mut State, rt| {
                         // get applied bottom-up nonce from subnet
-                        match st.get_subnet(rt,rt.store(), forwarder)
+                        match st.get_subnet(rt, forwarder)
                             .map_err(|_| actor_error!(illegal_argument, "error getting subnet from store in bottom-up execution"))?{
                                 Some(mut sub) => {
                                     if sub.applied_bottomup_nonce != cross_msg.msg.nonce {

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -99,7 +99,7 @@ impl Actor {
         let mut shid = SubnetID::default();
         rt.transaction(|st: &mut State, rt| {
             shid = SubnetID::new_from_parent(&st.network_name, subnet_addr);
-            let sub = st.get_subnet(rt.store(), &shid).map_err(|e| {
+            let sub = st.get_subnet(rt, rt.store(), &shid).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load subnet")
             })?;
             match sub {
@@ -140,7 +140,7 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             let shid = SubnetID::new_from_parent(&st.network_name, subnet_addr);
-            let sub = st.get_subnet(rt.store(), &shid).map_err(|e| {
+            let sub = st.get_subnet(rt, rt.store(), &shid).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load subnet")
             })?;
             match sub {
@@ -184,7 +184,7 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             let shid = SubnetID::new_from_parent(&st.network_name, subnet_addr);
-            let sub = st.get_subnet(rt.store(), &shid).map_err(|e| {
+            let sub = st.get_subnet(rt,rt.store(), &shid).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load subnet")
             })?;
             match sub {
@@ -235,7 +235,7 @@ impl Actor {
 
         rt.transaction(|st: &mut State, rt| {
             let shid = SubnetID::new_from_parent(&st.network_name, subnet_addr);
-            let sub = st.get_subnet(rt.store(), &shid).map_err(|e| {
+            let sub = st.get_subnet(rt,rt.store(), &shid).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load subnet")
             })?;
             match sub {
@@ -303,7 +303,7 @@ impl Actor {
             st.require_initialized()?;
 
             let shid = SubnetID::new_from_parent(&st.network_name, subnet_addr);
-            let sub = st.get_subnet(rt.store(), &shid).map_err(|e| {
+            let sub = st.get_subnet(rt, rt.store(), &shid).map_err(|e| {
                 e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "failed to load subnet")
             })?;
 
@@ -436,7 +436,7 @@ impl Actor {
             log::debug!("fund cross msg is: {:?}", f_msg);
 
             // Commit top-down message.
-            st.commit_topdown_msg(rt.store(), &mut f_msg).map_err(|e| {
+            st.commit_topdown_msg(rt, &mut f_msg).map_err(|e| {
                 e.downcast_default(
                     ExitCode::USR_ILLEGAL_STATE,
                     "error committing top-down message",
@@ -838,7 +838,7 @@ impl Actor {
                 // then we need to start propagating it down to the destination.
                 let r = if nearest_common_parent == st.network_name {
                     top_down_fee = fee;
-                    st.commit_topdown_msg(rt.store(), cross_msg)
+                    st.commit_topdown_msg(rt, cross_msg)
                 } else {
                     if cross_msg.msg.value > TokenAmount::zero() {
                         do_burn = true;
@@ -857,7 +857,7 @@ impl Actor {
             }
             IPCMsgType::TopDown => {
                 st.applied_topdown_nonce += 1;
-                st.commit_topdown_msg(rt.store(), cross_msg).map_err(|e| {
+                st.commit_topdown_msg(rt, cross_msg).map_err(|e| {
                     e.downcast_default(
                         ExitCode::USR_ILLEGAL_STATE,
                         "error committing top-down message while applying it",
@@ -922,7 +922,7 @@ impl Actor {
                 if sto == st.network_name {
                     rt.transaction(|st: &mut State, rt| {
                         // get applied bottom-up nonce from subnet
-                        match st.get_subnet(rt.store(), forwarder)
+                        match st.get_subnet(rt,rt.store(), forwarder)
                             .map_err(|_| actor_error!(illegal_argument, "error getting subnet from store in bottom-up execution"))?{
                                 Some(mut sub) => {
                                     if sub.applied_bottomup_nonce != cross_msg.msg.nonce {

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -126,7 +126,6 @@ impl State {
         rt: &impl Runtime,
         id: &SubnetID,
     ) -> anyhow::Result<Option<Subnet>> {
-        // resolve the underlying f0-based representation of the subnetID
         let subnets = self.subnets.load(rt.store())?;
         let subnet = get_subnet(&subnets, &id.f0_id(rt))?;
         Ok(subnet.cloned())

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -121,16 +121,14 @@ impl State {
     }
 
     /// Get content for a child subnet as mut.
-    pub fn get_subnet<BS: Blockstore>(
+    pub fn get_subnet(
         &mut self,
         rt: &impl Runtime,
-        store: &BS,
         id: &SubnetID,
     ) -> anyhow::Result<Option<Subnet>> {
         // resolve the underlying f0-based representation of the subnetID
-        let id = from_f2_to_f0_id(rt, id);
-        let subnets = self.subnets.load(store)?;
-        let subnet = get_subnet(&subnets, &id)?;
+        let subnets = self.subnets.load(rt.store())?;
+        let subnet = get_subnet(&subnets, &id.f0_id(rt))?;
         Ok(subnet.cloned())
     }
 
@@ -265,7 +263,6 @@ impl State {
         let sub = self
             .get_subnet(
                 rt,
-                rt.store(),
                 match &sto.down(&self.network_name) {
                     Some(sub) => sub,
                     None => return Err(anyhow!("couldn't compute the next subnet in route")),
@@ -465,17 +462,4 @@ pub fn get_topdown_msg<'m, BS: Blockstore>(
         .map_err(|e| anyhow!("failed to get msg by nonce: {:?}", e))?
         .map(|c| &c.msg);
     Ok(r)
-}
-
-/// Translate the SubnetID from an f2-based address to its
-/// corresponding f0 address used throughout the actor.
-fn from_f2_to_f0_id(rt: &impl Runtime, sn: &SubnetID) -> SubnetID {
-    let children = sn
-        .children_as_ref()
-        .iter()
-        // FIXME: I guess it is OK if we panic the actor here, but should we handle it more elegantly?
-        .map(|a| rt.resolve_address(a).unwrap())
-        .collect();
-
-    SubnetID::new(sn.root_id(), children)
 }

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -51,7 +51,7 @@ impl SubnetID {
     }
 
     /// Ensures that the SubnetID only uses f0 addresses for the subnet actor
-    /// hosted in the current network address. The rest of the route is left
+    /// hosted in the current network. The rest of the route is left
     /// as-is. We only have information to translate from f2 to f0 for the
     /// last subnet actor in the root.
     pub fn f0_id(&self, rt: &impl Runtime) -> SubnetID {

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -59,7 +59,7 @@ impl SubnetID {
 
         // replace the resolved child (if any)
         if let Some(actor_addr) = children.last_mut() {
-            if let Some(f0) = rt.resolve_address(&actor_addr) {
+            if let Some(f0) = rt.resolve_address(actor_addr) {
                 *actor_addr = f0;
             }
         }

--- a/subnet-actor/src/lib.rs
+++ b/subnet-actor/src/lib.rs
@@ -87,7 +87,7 @@ impl SubnetActor for Actor {
         // useful once we support the docking of subnets to new parents, etc.
         // let genesis_epoch = rt.curr_epoch();
         let genesis_epoch = 0;
-        let st = State::new(rt.store(), params, genesis_epoch).map_err(|e| {
+        let st = State::new(rt, params, genesis_epoch).map_err(|e| {
             e.downcast_default(ExitCode::USR_ILLEGAL_STATE, "Failed to create actor state")
         })?;
 

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -64,11 +64,12 @@ pub struct State {
 /// and have load and save methods automatically generated for them as part of a
 /// StateObject trait (i.e. impl StateObject for State).
 impl State {
-    pub fn new<BS: Blockstore>(
-        store: &BS,
+    pub fn new(
+        rt: &mut impl Runtime,
         params: ConstructParams,
         current_epoch: ChainEpoch,
     ) -> anyhow::Result<State> {
+        let store = rt.store();
         let min_stake = TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT);
         let bottomup_check_period = if params.bottomup_check_period < DEFAULT_CHECKPOINT_PERIOD {
             DEFAULT_CHECKPOINT_PERIOD
@@ -82,7 +83,7 @@ impl State {
         };
         let state = State {
             name: params.name,
-            parent_id: params.parent,
+            parent_id: params.parent.f0_id(rt),
             ipc_gateway_addr: Address::new_id(params.ipc_gateway_addr),
             consensus: params.consensus,
             total_stake: TokenAmount::zero(),


### PR DESCRIPTION
Updates `get_subnet` to use as a reference the f0-based SubnetID while still supporting the use of robust addresses for the interaction with the actor.
