### PR TITLE
update create subnet gateway type to address

### DIFF
--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -83,7 +83,7 @@ impl State {
         let state = State {
             name: params.name,
             parent_id: params.parent,
-            ipc_gateway_addr: Address::new_id(params.ipc_gateway_addr),
+            ipc_gateway_addr: params.ipc_gateway_addr,
             consensus: params.consensus,
             total_stake: TokenAmount::zero(),
             min_validator_stake: if params.min_validator_stake < min_stake {

--- a/subnet-actor/src/types.rs
+++ b/subnet-actor/src/types.rs
@@ -111,7 +111,7 @@ pub enum Status {
 pub struct ConstructParams {
     pub parent: SubnetID,
     pub name: String,
-    pub ipc_gateway_addr: u64,
+    pub ipc_gateway_addr: Address,
     pub consensus: ConsensusType,
     pub min_validator_stake: TokenAmount,
     pub min_validators: u64,

--- a/subnet-actor/tests/actor_test.rs
+++ b/subnet-actor/tests/actor_test.rs
@@ -42,7 +42,7 @@ mod test {
         ConstructParams {
             parent: SubnetID::from_str(ROOT_STR_ID).unwrap(),
             name: NETWORK_NAME.to_string(),
-            ipc_gateway_addr: IPC_GATEWAY_ADDR,
+            ipc_gateway_addr: Address::new_id(IPC_GATEWAY_ADDR),
             consensus: ConsensusType::Dummy,
             min_validator_stake: Default::default(),
             min_validators: 0,


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Change the create subnet parameter's gateway type from `u64` to `Address`. This is because we need to support f4 address type, i.e. EVM address, using an id might not work for EVM.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo test --all
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Related to https://github.com/consensus-shipyard/ipc-agent/pull/223
