### PR TITLE
chore: remove unused consensusTypes

### DIFF
--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -154,8 +154,6 @@ impl State {
                     .validators()
                     .iter()
                     .any(|x| x.addr == *addr)
-                    && (self.consensus != ConsensusType::Delegated
-                        || self.validator_set.validators().is_empty())
                 {
                     self.validator_set.push(Validator {
                         addr: *addr,
@@ -344,7 +342,7 @@ impl Default for State {
             name: String::new(),
             parent_id: SubnetID::default(),
             ipc_gateway_addr: Address::new_id(0),
-            consensus: ConsensusType::Delegated,
+            consensus: ConsensusType::Mir,
             min_validator_stake: TokenAmount::from_atto(MIN_COLLATERAL_AMOUNT),
             total_stake: TokenAmount::zero(),
             bottomup_check_period: 0,

--- a/subnet-actor/src/types.rs
+++ b/subnet-actor/src/types.rs
@@ -89,12 +89,7 @@ pub struct Votes {
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize_repr, Serialize_repr)]
 #[repr(u64)]
 pub enum ConsensusType {
-    Delegated,
-    PoW,
-    Tendermint,
     Mir,
-    FilecoinEC,
-    Dummy,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize_repr, Serialize_repr)]

--- a/subnet-actor/tests/actor_test.rs
+++ b/subnet-actor/tests/actor_test.rs
@@ -43,7 +43,7 @@ mod test {
             parent: SubnetID::from_str(ROOT_STR_ID).unwrap(),
             name: NETWORK_NAME.to_string(),
             ipc_gateway_addr: Address::new_id(IPC_GATEWAY_ADDR),
-            consensus: ConsensusType::Dummy,
+            consensus: ConsensusType::Mir,
             min_validator_stake: Default::default(),
             min_validators: 0,
             topdown_check_period: 0,


### PR DESCRIPTION
Leaving as the only `ConsensusType` the only that we support which is Mir.