### PR TITLE
Add target address to fund and release

### DIFF
--- a/atomic-exec/Cargo.toml
+++ b/atomic-exec/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "ipc_atomic_execution"
-version = "0.0.1"
-license = "MIT OR Apache-2.0"
 authors = ["ConsensusLab", "Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
-repository = "https://github.com/consensus-shipyard/ipc-atomic-execution"
 keywords = ["filecoin", "web3", "wasm"]
+license = "MIT OR Apache-2.0"
+name = "ipc_atomic_execution"
+repository = "https://github.com/consensus-shipyard/ipc-atomic-execution"
+version = "0.0.1"
 
 [lib]
 ## lib is necessary for integration tests
@@ -13,32 +13,32 @@ keywords = ["filecoin", "web3", "wasm"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-ipc_gateway = { path = "../gateway", package = "ipc-gateway", features = [] }
+ipc_gateway = {path = "../gateway", package = "ipc-gateway", features = []}
 
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
-primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
-fvm_ipld_hamt = "0.5.1"
+fil_actors_runtime = {git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"]}
+frc42_dispatch = "3.2.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
-frc42_dispatch = "3.0.0"
+fvm_ipld_hamt = "0.5.1"
+fvm_shared = {version = "3.2.0", default-features = false}
+primitives = {git = "https://github.com/consensus-shipyard/fvm-utils"}
 
-num-traits = "0.2.14"
-num-derive = "0.3.3"
-log = "0.4.14"
-indexmap = { version = "1.8.0", features = ["serde-1"] }
-cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-integer-encoding = { version = "3.0.3", default-features = false }
-lazy_static = "1.4.0"
-serde_tuple = "0.5"
-serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.56"
+cid = {version = "0.8.3", default-features = false, features = ["serde-codec"]}
+indexmap = {version = "1.8.0", features = ["serde-1"]}
+integer-encoding = {version = "3.0.3", default-features = false}
+lazy_static = "1.4.0"
+log = "0.4.14"
+num-derive = "0.3.3"
+num-traits = "0.2.14"
+serde = {version = "1.0.136", features = ["derive"]}
+serde_tuple = "0.5"
 thiserror = "1.0.38"
 unsigned-varint = "0.7.1"
 
 [dev-dependencies]
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor", "test_utils"] }
-ipc-sdk = { path = "../sdk" }
+fil_actors_runtime = {git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor", "test_utils"]}
+ipc-sdk = {path = "../sdk"}
 
 [build-dependencies]
 wasm-builder = "3.0.1"

--- a/atomic-exec/examples/fungible-token/Cargo.toml
+++ b/atomic-exec/examples/fungible-token/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "ipc_atomic_exec_fungible_token_sample"
-version = "0.1.0"
-license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs and the contributors"]
 edition = "2018"
-repository = "https://github.com/consensus-shipyard/ipc-atomic-execution"
 keywords = ["web3", "filecoin", "FVM", "inter-planetary consensus"]
+license = "MIT OR Apache-2.0"
+name = "ipc_atomic_exec_fungible_token_sample"
+repository = "https://github.com/consensus-shipyard/ipc-atomic-execution"
+version = "0.1.0"
 
 [lib]
 ## lib is necessary for integration tests
@@ -13,33 +13,33 @@ keywords = ["web3", "filecoin", "FVM", "inter-planetary consensus"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-ipc_atomic_execution = { path = "../../" }
-ipc_atomic_execution_primitives = { path = "../../primitives/" }
-ipc_gateway = { path = "../../../gateway", package = "ipc-gateway" }
+ipc_atomic_execution = {path = "../../"}
+ipc_atomic_execution_primitives = {path = "../../primitives/"}
+ipc_gateway = {path = "../../../gateway", package = "ipc-gateway"}
 
-fvm_primitives = { git = "https://github.com/consensus-shipyard/fvm-utils", package = "primitives" }
-fvm_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", package = "fil_actors_runtime", features = ["fil-actor"] }
+fvm_actors_runtime = {git = "https://github.com/consensus-shipyard/fvm-utils", package = "fil_actors_runtime", features = ["fil-actor"]}
+fvm_primitives = {git = "https://github.com/consensus-shipyard/fvm-utils", package = "primitives"}
 
-frc42_dispatch = "3.0.0"
+frc42_dispatch = "3.2.0"
 
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
-fvm_ipld_hamt = "0.5.1"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
+fvm_ipld_hamt = "0.5.1"
+fvm_shared = {version = "3.2.0", default-features = false}
 
-cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-serde_tuple = "0.5"
-serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.56"
-thiserror = "1.0.37"
+cid = {version = "0.8.3", default-features = false, features = ["serde-codec"]}
 integer-encoding = "3.0.4"
+lazy_static = "1.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
-lazy_static = "1.4.0"
+serde = {version = "1.0.136", features = ["derive"]}
+serde_tuple = "0.5"
+thiserror = "1.0.37"
 
 [dev-dependencies]
-fvm_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", package = "fil_actors_runtime", features = ["fil-actor", "test_utils"] }
-ipc-sdk = { path = "../../../sdk" }
+fvm_actors_runtime = {git = "https://github.com/consensus-shipyard/fvm-utils", package = "fil_actors_runtime", features = ["fil-actor", "test_utils"]}
+ipc-sdk = {path = "../../../sdk"}
 
 [build-dependencies]
 wasm-builder = "3.0.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
-name = "ipc-actor-common"
 description = "The common code used by both gateway actor and subnet actor, but not by sdk exposed to users"
-version = "0.1.0"
 edition = "2021"
+name = "ipc-actor-common"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.56"
-log = "0.4.17"
-primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
-ipc-sdk = { path = "../sdk" }
-num-traits = "0.2.14"
+fil_actors_runtime = {git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"]}
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
+fvm_shared = {version = "=3.2.0", default-features = false}
+integer-encoding = {version = "3.0.3", default-features = false}
+ipc-sdk = {path = "../sdk"}
 lazy_static = "1.4.0"
+log = "0.4.17"
+num-traits = "0.2.14"
+primitives = {git = "https://github.com/consensus-shipyard/fvm-utils"}
+serde = {version = "1.0.136", features = ["derive"]}
 serde_tuple = "0.5"
-serde = { version = "1.0.136", features = ["derive"] }
-fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 thiserror = "1.0.38"
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
-integer-encoding = { version = "3.0.3", default-features = false }
 
 [dev-dependencies]
-serde_json = "1.0.95"
 cid = "0.8.6"
+serde_json = "1.0.95"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "ipc-gateway"
-description = "IPC Gateway Actor"
-version = "0.0.1"
-license = "MIT OR Apache-2.0"
 authors = ["ConsensusLab", "Protocol Labs", "Filecoin Core Devs"]
+description = "IPC Gateway Actor"
 edition = "2021"
-repository = "https://github.com/consensus-shipyard/ipc-actors"
 keywords = ["filecoin", "web3", "wasm", "ipc"]
+license = "MIT OR Apache-2.0"
+name = "ipc-gateway"
+repository = "https://github.com/consensus-shipyard/ipc-actors"
+version = "0.0.1"
 
 [lib]
 ## lib is necessary for integration tests
@@ -14,33 +14,33 @@ keywords = ["filecoin", "web3", "wasm", "ipc"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
-frc42_dispatch = "3.0.0"
-primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
-fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
-ipc-sdk = { path = "../sdk" }
-ipc-actor-common = { path = "../common" }
-fvm_ipld_hamt = "0.5.1"
-num-traits = "0.2.14"
-num-derive = "0.3.3"
-log = "0.4.14"
-indexmap = { version = "1.8.0", features = ["serde-1"] }
-cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-integer-encoding = { version = "3.0.3", default-features = false }
-lazy_static = "1.4.0"
-serde_tuple = "0.5"
-serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.56"
+cid = {version = "0.8.3", default-features = false, features = ["serde-codec"]}
+fil_actors_runtime = {git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"]}
+frc42_dispatch = "3.2.0"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
+fvm_ipld_hamt = "0.5.1"
+fvm_shared = {version = "=3.2.0", default-features = false}
+indexmap = {version = "1.8.0", features = ["serde-1"]}
+integer-encoding = {version = "3.0.3", default-features = false}
+ipc-actor-common = {path = "../common"}
+ipc-sdk = {path = "../sdk"}
+lazy_static = "1.4.0"
+log = "0.4.14"
+num-derive = "0.3.3"
+num-traits = "0.2.14"
+primitives = {git = "https://github.com/consensus-shipyard/fvm-utils"}
+serde = {version = "1.0.136", features = ["derive"]}
+serde_tuple = "0.5"
 thiserror = "1.0.37"
 unsigned-varint = "0.7.1"
 
 [dev-dependencies]
 # enable test_utils feature only in dev env
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor", "test_utils"] }
 base64 = "0.13.1"
 env_logger = "0.10.0"
+fil_actors_runtime = {git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor", "test_utils"]}
 
 [build-dependencies]
 wasm-builder = "3.0.1"

--- a/gateway/src/cross.rs
+++ b/gateway/src/cross.rs
@@ -78,7 +78,8 @@ impl CrossMsg {
 impl StorableMsg {
     pub fn new_release_msg(
         sub_id: &SubnetID,
-        sig_addr: &Address,
+        from: &Address,
+        to: &Address,
         value: TokenAmount,
     ) -> anyhow::Result<Self> {
         let to = IPCAddress::new(
@@ -86,9 +87,9 @@ impl StorableMsg {
                 Some(s) => s,
                 None => return Err(anyhow!("error getting parent for subnet addr")),
             },
-            sig_addr,
+            to,
         )?;
-        let from = IPCAddress::new(sub_id, &BURNT_FUNDS_ACTOR_ADDR)?;
+        let from = IPCAddress::new(sub_id, from)?;
         Ok(Self {
             from,
             to,
@@ -101,7 +102,8 @@ impl StorableMsg {
 
     pub fn new_fund_msg(
         sub_id: &SubnetID,
-        sig_addr: &Address,
+        from: &Address,
+        to: &Address,
         value: TokenAmount,
     ) -> anyhow::Result<Self> {
         let from = IPCAddress::new(
@@ -109,9 +111,9 @@ impl StorableMsg {
                 Some(s) => s,
                 None => return Err(anyhow!("error getting parent for subnet addr")),
             },
-            sig_addr,
+            from,
         )?;
-        let to = IPCAddress::new(sub_id, sig_addr)?;
+        let to = IPCAddress::new(sub_id, to)?;
         // the nonce and the rest of message fields are set when the message is committed.
         Ok(Self {
             from,

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -177,7 +177,7 @@ impl State {
         let deleted = self.subnets.modify(store, |subnets| {
             subnets
                 .delete(&id.to_bytes())
-                .map_err(|e| e.downcast_wrap(format!("failed to delete subnet for id {}", id)))
+                .map_err(|e| e.downcast_wrap(format!("failed to delete subnet for id {id}")))
                 .map(|x| x.is_some())
         })?;
         if deleted {
@@ -419,7 +419,7 @@ pub fn set_subnet<BS: Blockstore>(
 ) -> anyhow::Result<()> {
     subnets
         .set(id.to_bytes().into(), subnet)
-        .map_err(|e| e.downcast_wrap(format!("failed to set subnet for id {}", id)))?;
+        .map_err(|e| e.downcast_wrap(format!("failed to set subnet for id {id}")))?;
     Ok(())
 }
 
@@ -429,7 +429,7 @@ fn get_subnet<'m, BS: Blockstore>(
 ) -> anyhow::Result<Option<&'m Subnet>> {
     subnets
         .get(&id.to_bytes())
-        .map_err(|e| e.downcast_wrap(format!("failed to get subnet for id {}", id)))
+        .map_err(|e| e.downcast_wrap(format!("failed to get subnet for id {id}")))
 }
 
 pub fn set_checkpoint<BS: Blockstore>(
@@ -439,7 +439,7 @@ pub fn set_checkpoint<BS: Blockstore>(
     let epoch = ch.epoch();
     checkpoints
         .set(epoch_key(epoch), ch)
-        .map_err(|e| e.downcast_wrap(format!("failed to set checkpoint for epoch {}", epoch)))?;
+        .map_err(|e| e.downcast_wrap(format!("failed to set checkpoint for epoch {epoch}")))?;
     Ok(())
 }
 
@@ -449,7 +449,7 @@ pub fn get_checkpoint<'m, BS: Blockstore>(
 ) -> anyhow::Result<Option<&'m BottomUpCheckpoint>> {
     checkpoints
         .get(&epoch_key(epoch))
-        .map_err(|e| e.downcast_wrap(format!("failed to get checkpoint for id {}", epoch)))
+        .map_err(|e| e.downcast_wrap(format!("failed to get checkpoint for id {epoch}")))
 }
 
 pub fn get_topdown_msg<'m, BS: Blockstore>(

--- a/gateway/src/types.rs
+++ b/gateway/src/types.rs
@@ -107,8 +107,8 @@ pub(crate) fn resolved_from_to(
     from: &Address,
     to: &Address,
 ) -> Result<(Address, Address), ActorError> {
-    let mut from_sig_addr = from.clone();
-    let mut to_sig_addr = to.clone();
+    let mut from_sig_addr = *from;
+    let mut to_sig_addr = *to;
     let mut resolved = false;
 
     if to.protocol() != Protocol::Delegated {
@@ -118,16 +118,15 @@ pub(crate) fn resolved_from_to(
 
     // Check if they are equal to save ourselves a resolution
     if resolved {
-        if !equal_account_id(rt, &from_sig_addr, &to)? {
+        if !equal_account_id(rt, &from_sig_addr, to)? {
             from_sig_addr = resolve_secp_bls(rt, &from_sig_addr)?;
         } else {
             from_sig_addr = to_sig_addr;
         }
-    } else {
-        if from.protocol() != Protocol::Delegated {
-            from_sig_addr = resolve_secp_bls(rt, &from_sig_addr)?;
-        }
+    } else if from.protocol() != Protocol::Delegated {
+        from_sig_addr = resolve_secp_bls(rt, &from_sig_addr)?;
     }
+
     Ok((from_sig_addr, to_sig_addr))
 }
 

--- a/gateway/tests/gateway_test.rs
+++ b/gateway/tests/gateway_test.rs
@@ -373,6 +373,7 @@ fn checkpoint_crossmsgs() {
     h.fund(
         &mut rt,
         &funder,
+        &funder,
         &shid,
         ExitCode::OK,
         amount.clone(),
@@ -439,10 +440,12 @@ fn test_fund() {
     h.check_state();
 
     let funder = Address::new_id(1001);
+    let other = Address::new_id(1002);
     let amount = TokenAmount::from_atto(10_u64.pow(18));
     h.fund(
         &mut rt,
         &funder,
+        &other,
         &shid,
         ExitCode::OK,
         amount.clone(),
@@ -455,6 +458,7 @@ fn test_fund() {
     h.fund(
         &mut rt,
         &funder,
+        &funder,
         &shid,
         ExitCode::OK,
         amount.clone(),
@@ -466,6 +470,7 @@ fn test_fund() {
     h.fund(
         &mut rt,
         &funder,
+        &funder,
         &shid,
         ExitCode::OK,
         amount.clone(),
@@ -476,6 +481,7 @@ fn test_fund() {
     // No funds sent
     h.fund(
         &mut rt,
+        &funder,
         &funder,
         &shid,
         ExitCode::USR_ILLEGAL_ARGUMENT,
@@ -489,10 +495,40 @@ fn test_fund() {
     h.fund(
         &mut rt,
         &funder,
+        &funder,
         &SubnetID::new_from_parent(&h.net_name, *SUBNET_TWO),
         ExitCode::USR_ILLEGAL_ARGUMENT,
         TokenAmount::zero(),
         3,
+        &exp_cs,
+    )
+    .unwrap();
+
+    // use delegated address
+    let other = Address::from_str("f410fnpq4z5siy5eaaoanauqnpf5bodearnren5fxyoi").unwrap();
+    exp_cs += amount.clone();
+    h.fund(
+        &mut rt,
+        &funder,
+        &other,
+        &shid,
+        ExitCode::OK,
+        amount.clone(),
+        4,
+        &exp_cs,
+    )
+    .unwrap();
+
+    // actor addresses not supported
+    let other = Address::from_str("f2xwzbdu7z5sam6hc57xxwkctciuaz7oe5omipwbq").unwrap();
+    h.fund(
+        &mut rt,
+        &funder,
+        &other,
+        &shid,
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        amount.clone(),
+        4,
         &exp_cs,
     )
     .unwrap();
@@ -504,17 +540,80 @@ fn test_release() {
     let (h, mut rt) = setup(shid.clone());
 
     let releaser = Address::new_id(1001);
+    let to = Address::new_id(1002);
     // Release funds
     let r_amount = TokenAmount::from_atto(5_u64.pow(18));
-    rt.set_balance(4 * r_amount.clone());
-    h.release(&mut rt, &releaser, ExitCode::OK, r_amount.clone(), 2, 0, 0)
-        .unwrap();
-    h.release(&mut rt, &releaser, ExitCode::OK, r_amount.clone(), 3, 1, 1)
-        .unwrap();
-    h.release(&mut rt, &releaser, ExitCode::OK, r_amount.clone(), 10, 2, 0)
-        .unwrap();
-    h.release(&mut rt, &releaser, ExitCode::OK, r_amount, 11, 3, 1)
-        .unwrap();
+    rt.set_balance(6 * r_amount.clone());
+    h.release(
+        &mut rt,
+        &releaser,
+        &to,
+        ExitCode::OK,
+        r_amount.clone(),
+        2,
+        0,
+        0,
+    )
+    .unwrap();
+    h.release(
+        &mut rt,
+        &releaser,
+        &to,
+        ExitCode::OK,
+        r_amount.clone(),
+        3,
+        1,
+        1,
+    )
+    .unwrap();
+    h.release(
+        &mut rt,
+        &releaser,
+        &to,
+        ExitCode::OK,
+        r_amount.clone(),
+        10,
+        2,
+        0,
+    )
+    .unwrap();
+    h.release(
+        &mut rt,
+        &releaser,
+        &to,
+        ExitCode::OK,
+        r_amount.clone(),
+        11,
+        3,
+        1,
+    )
+    .unwrap();
+
+    // use delegated address
+    let to = Address::from_str("f410fnpq4z5siy5eaaoanauqnpf5bodearnren5fxyoi").unwrap();
+    h.release(
+        &mut rt,
+        &releaser,
+        &to,
+        ExitCode::OK,
+        r_amount.clone(),
+        11,
+        4,
+        2,
+    )
+    .unwrap();
+    let to = Address::from_str("f2xwzbdu7z5sam6hc57xxwkctciuaz7oe5omipwbq").unwrap();
+    h.release(
+        &mut rt,
+        &releaser,
+        &to,
+        ExitCode::USR_ILLEGAL_ARGUMENT,
+        r_amount,
+        11,
+        4,
+        2,
+    )
+    .unwrap();
 }
 
 #[test]
@@ -637,6 +736,7 @@ fn test_commit_child_check_bu_target_subnet() {
     h.fund(
         &mut rt,
         &Address::new_id(1001),
+        &Address::new_id(1001),
         &shid,
         ExitCode::OK,
         TokenAmount::from_atto(10_u64.pow(18)),
@@ -721,6 +821,7 @@ fn test_commit_child_check_bu_not_target_subnet() {
     .unwrap();
     h.fund(
         &mut rt,
+        &Address::new_id(1001),
         &Address::new_id(1001),
         &shid,
         ExitCode::OK,
@@ -849,6 +950,7 @@ fn test_propagate_with_remainder() {
     .unwrap();
     h.fund(
         &mut rt,
+        &Address::new_id(1001),
         &Address::new_id(1001),
         &shid,
         ExitCode::OK,
@@ -1089,6 +1191,7 @@ fn test_commit_child_check_tp_target_subnet() {
     h.fund(
         &mut rt,
         &Address::new_id(1001),
+        &Address::new_id(1001),
         &shid,
         ExitCode::OK,
         TokenAmount::from_atto(10_u64.pow(18)),
@@ -1166,6 +1269,7 @@ fn test_commit_child_check_tp_not_target_subnet() {
     let funder = Address::new_id(1002);
     h.fund(
         &mut rt,
+        &funder,
         &funder,
         &sub,
         ExitCode::OK,

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,31 +1,30 @@
 [package]
-name = "ipc-sdk"
-description = "Common types and util functions for IPC actors"
-version = "0.0.1"
-license = "MIT OR Apache-2.0"
 authors = ["ConsensusLab", "Protocol Labs", "Filecoin Core Devs"]
+description = "Common types and util functions for IPC actors"
 edition = "2021"
-repository = "https://github.com/consensus-shipyard/ipc-actors"
 keywords = ["filecoin", "web3", "wasm", "ipc"]
+license = "MIT OR Apache-2.0"
+name = "ipc-sdk"
+repository = "https://github.com/consensus-shipyard/ipc-actors"
+version = "0.0.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.56"
-log = "0.4.17"
-primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
-num-traits = "0.2.14"
+fil_actors_runtime = {git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"]}
+fnv = "1.0.7"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
+fvm_shared = {version = "=3.2.0", default-features = false}
+integer-encoding = {version = "3.0.3", default-features = false}
 lazy_static = "1.4.0"
-fnv = "1.0.7"
+log = "0.4.17"
+num-traits = "0.2.14"
+primitives = {git = "https://github.com/consensus-shipyard/fvm-utils"}
+serde = {version = "1.0.136", features = ["derive"]}
 serde_tuple = "0.5"
-serde = { version = "1.0.136", features = ["derive"] }
-fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 thiserror = "1.0.38"
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
-integer-encoding = { version = "3.0.3", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.95"
-

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -53,23 +53,20 @@ impl IPCAddress {
     /// Checks if a raw address has a valid Filecoin address protocol
     /// compatible with cross-net messages targetting a contract
     pub fn is_valid_contract_address(addr: &Address) -> bool {
-        match addr.protocol() {
-            Protocol::Delegated | Protocol::Actor => true,
-            _ => false,
-        }
+        matches!(addr.protocol(), Protocol::Delegated | Protocol::Actor)
     }
 
     /// Checks if a raw address has a valid Filecoin address protocol
     /// compatible with cross-net messages targetting a user account
     pub fn is_valid_account_address(addr: &Address) -> bool {
-        match addr.protocol() {
-            // we support `Delegated` as a type for a valid account address
-            // so we can send funds to eth addresses using cross-net primitives.
-            // this may require additional care when executing in FEVM so we don't
-            // send funds to a smart contract.
-            Protocol::Delegated | Protocol::BLS | Protocol::Secp256k1 | Protocol::ID => true,
-            _ => false,
-        }
+        // we support `Delegated` as a type for a valid account address
+        // so we can send funds to eth addresses using cross-net primitives.
+        // this may require additional care when executing in FEVM so we don't
+        // send funds to a smart contract.
+        matches!(
+            addr.protocol(),
+            Protocol::Delegated | Protocol::BLS | Protocol::Secp256k1 | Protocol::ID
+        )
     }
 }
 

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -192,7 +192,7 @@ impl fmt::Display for SubnetID {
         let children_str = self
             .children_as_ref()
             .iter()
-            .map(|s| format!("/{}", s))
+            .map(|s| format!("/{s}"))
             .collect::<String>();
 
         write!(f, "/r{}{}", self.root_id(), children_str)

--- a/subnet-actor/Cargo.toml
+++ b/subnet-actor/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "ipc-subnet-actor"
-description = "IPC subnet actor code"
-version = "0.0.1"
-license = "MIT OR Apache-2.0"
 authors = ["ConsensusLab", "Protocol Labs", "Filecoin Core Devs"]
+description = "IPC subnet actor code"
 edition = "2021"
-repository = "https://github.com/consensus-shipyard/ipc-actors"
 keywords = ["filecoin", "web3", "wasm", "ipc"]
+license = "MIT OR Apache-2.0"
+name = "ipc-subnet-actor"
+repository = "https://github.com/consensus-shipyard/ipc-actors"
+version = "0.0.1"
 
 [lib]
 ## lib is necessary for integration tests
@@ -14,34 +14,34 @@ keywords = ["filecoin", "web3", "wasm", "ipc"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
-frc42_dispatch = "3.0.0 "
-ipc-gateway = { path = "../gateway" }
-ipc-sdk = { path = "../sdk" }
-ipc-actor-common = { path = "../common" }
-primitives = { git = "https://github.com/consensus-shipyard/fvm-utils"}
-fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
-fvm_ipld_hamt = "0.5.1"
-num-traits = "0.2.14"
-num-derive = "0.3.3"
-log = "0.4.14"
-indexmap = { version = "1.8.0", features = ["serde-1"] }
-cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
-integer-encoding = { version = "3.0.3", default-features = false }
-lazy_static = "1.4.0"
-serde_tuple = "0.5"
-serde = { version = "1.0.136", features = ["derive"] }
 anyhow = "1.0.56"
+cid = {version = "0.8.3", default-features = false, features = ["serde-codec"]}
+fil_actors_runtime = {git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"]}
+frc42_dispatch = "3.0.0 "
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
+fvm_ipld_hamt = "0.5.1"
+fvm_shared = {version = "=3.2.0", default-features = false}
+indexmap = {version = "1.8.0", features = ["serde-1"]}
+integer-encoding = {version = "3.0.3", default-features = false}
+ipc-actor-common = {path = "../common"}
+ipc-gateway = {path = "../gateway"}
+ipc-sdk = {path = "../sdk"}
+lazy_static = "1.4.0"
+log = "0.4.14"
+num = "0.4.0"
+num-derive = "0.3.3"
+num-traits = "0.2.14"
+primitives = {git = "https://github.com/consensus-shipyard/fvm-utils"}
+serde = {version = "1.0.136", features = ["derive"]}
+serde_tuple = "0.5"
 thiserror = "1.0.37"
 unsigned-varint = "0.7.1"
-num = "0.4.0"
 
 [dev-dependencies]
 # Enable test-utils only in dev
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor", "test_utils"] }
 base64 = "0.13.1"
+fil_actors_runtime = {git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor", "test_utils"]}
 
 [build-dependencies]
 wasm-builder = "3.0.1"

--- a/subnet-actor/src/lib.rs
+++ b/subnet-actor/src/lib.rs
@@ -14,7 +14,7 @@ use fvm_ipld_encoding::RawBytes;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR, METHOD_SEND};
-use ipc_gateway::{BottomUpCheckpoint, FundParams, MIN_COLLATERAL_AMOUNT};
+use ipc_gateway::{AmountParams, BottomUpCheckpoint, MIN_COLLATERAL_AMOUNT};
 use num::BigInt;
 use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, Zero};
@@ -171,7 +171,7 @@ impl SubnetActor for Actor {
                 msg = Some(CrossActorPayload::new(
                     st.ipc_gateway_addr,
                     ipc_gateway::Method::ReleaseStake as u64,
-                    IpldBlock::serialize_cbor(&FundParams {
+                    IpldBlock::serialize_cbor(&AmountParams {
                         value: stake.clone(),
                     })?,
                     TokenAmount::zero(),

--- a/subnet-actor/src/lib.rs
+++ b/subnet-actor/src/lib.rs
@@ -273,7 +273,7 @@ impl SubnetActor for Actor {
 
         state
             .verify_checkpoint(rt, &ch)
-            .map_err(|e| actor_error!(illegal_state, format!("checkpoint failed: {}", e)))?;
+            .map_err(|e| actor_error!(illegal_state, format!("checkpoint failed: {e}")))?;
 
         let msg = rt.transaction(|st: &mut State, rt| {
             let store = rt.store();

--- a/subnet-actor/src/state.rs
+++ b/subnet-actor/src/state.rs
@@ -187,8 +187,7 @@ impl State {
 
             if stake.lt(&ret_amount) {
                 return Err(anyhow!(format!(
-                    "address not enough stake to withdraw: {:?}",
-                    addr
+                    "address not enough stake to withdraw: {addr:?}"
                 )));
             }
 

--- a/subnet-actor/tests/actor_test.rs
+++ b/subnet-actor/tests/actor_test.rs
@@ -16,7 +16,7 @@ mod test {
     use fvm_shared::error::ExitCode;
     use fvm_shared::METHOD_SEND;
     use ipc_gateway::{
-        BottomUpCheckpoint, FundParams, SubnetID, CHECKPOINT_GENESIS_CID, MIN_COLLATERAL_AMOUNT,
+        AmountParams, BottomUpCheckpoint, SubnetID, CHECKPOINT_GENESIS_CID, MIN_COLLATERAL_AMOUNT,
     };
     use ipc_subnet_actor::{
         Actor, ConsensusType, ConstructParams, JoinParams, Method, State, Status,
@@ -515,7 +515,7 @@ mod test {
         runtime.expect_send(
             Address::new_id(IPC_GATEWAY_ADDR),
             ipc_gateway::Method::ReleaseStake as u64,
-            IpldBlock::serialize_cbor(&FundParams {
+            IpldBlock::serialize_cbor(&AmountParams {
                 value: value.clone(),
             })
             .unwrap(),
@@ -561,7 +561,7 @@ mod test {
         runtime.expect_send(
             Address::new_id(IPC_GATEWAY_ADDR),
             ipc_gateway::Method::ReleaseStake as u64,
-            IpldBlock::serialize_cbor(&FundParams {
+            IpldBlock::serialize_cbor(&AmountParams {
                 value: value.clone(),
             })
             .unwrap(),
@@ -599,7 +599,7 @@ mod test {
         runtime.expect_send(
             Address::new_id(IPC_GATEWAY_ADDR),
             ipc_gateway::Method::ReleaseStake as u64,
-            IpldBlock::serialize_cbor(&FundParams {
+            IpldBlock::serialize_cbor(&AmountParams {
                 value: value.clone(),
             })
             .unwrap(),


### PR DESCRIPTION
This PR improved `fund` and `release` to support the use of `Delegated` address, and optionally be able to send funds to an address in a subnet immediately above or below. This is a requirement to support the interoperability between FVM and FEVM-based subnet runtimes.