### PR TITLE
minor improvement to checks

### DIFF
--- a/gateway/src/types.rs
+++ b/gateway/src/types.rs
@@ -118,7 +118,7 @@ pub(crate) fn resolved_from_to(
 
     // Check if they are equal to save ourselves a resolution
     if resolved {
-        if !equal_account_id(rt, &from_sig_addr, to)? {
+        if !equal_account_id(rt, &from_sig_addr, to) {
             from_sig_addr = resolve_secp_bls(rt, &from_sig_addr)?;
         } else {
             from_sig_addr = to_sig_addr;


### PR DESCRIPTION
Solves an issue for which release errores when a `to` account was not yet initialized on-chain in the subnet (something that is not actually a requirement for the operation). 