### PR TITLE
FM-162: FIL actor feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           override: true
       - run: cargo b --all
       - run: cargo t --all
+      # Check that the SDK compiles when default features are disabled.
+      - run: cargo check -p ipc-sdk --features ""
 
   fmt:
     name: Rustfmt

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -12,19 +12,27 @@ version = "0.0.1"
 
 [dependencies]
 anyhow = "1.0.56"
-fil_actors_runtime = {git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"]}
+fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", optional = true, features = [
+  "fil-actor",
+] }
 fnv = "1.0.7"
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
-fvm_shared = {version = "=3.2.0", default-features = false}
-integer-encoding = {version = "3.0.3", default-features = false}
+fvm_ipld_hamt = "0.6"
+fvm_shared = { version = "=3.2.0", default-features = false }
+integer-encoding = { version = "3.0.3", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.17"
 num-traits = "0.2.14"
-primitives = {git = "https://github.com/consensus-shipyard/fvm-utils"}
-serde = {version = "1.0.136", features = ["derive"]}
+primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
+serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5"
 thiserror = "1.0.38"
 
 [dev-dependencies]
 serde_json = "1.0.95"
+
+
+[features]
+default = []
+fil-actor = ["fil_actors_runtime"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -34,5 +34,5 @@ serde_json = "1.0.95"
 
 
 [features]
-default = []
+default = ["fil-actor"]
 fil-actor = ["fil_actors_runtime"]

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -1,7 +1,5 @@
 use crate::error::Error;
 use crate::subnet_id::SubnetID;
-use fil_actors_runtime::cbor;
-use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::{Address, Protocol};
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use std::str::FromStr;
@@ -34,12 +32,17 @@ impl IPCAddress {
     }
 
     /// Returns encoded bytes of Address
+    #[cfg(feature = "fil-actor")]
     pub fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(cbor::serialize(self, "ipc-address")?.to_vec())
+        Ok(fil_actors_runtime::cbor::serialize(self, "ipc-address")?.to_vec())
     }
 
+    #[cfg(feature = "fil-actor")]
     pub fn from_bytes(bz: &[u8]) -> Result<Self, Error> {
-        let i: Self = cbor::deserialize(&RawBytes::new(bz.to_vec()), "ipc-address")?;
+        let i: Self = fil_actors_runtime::cbor::deserialize(
+            &fvm_ipld_encoding::RawBytes::new(bz.to_vec()),
+            "ipc-address",
+        )?;
         Ok(i)
     }
 
@@ -118,6 +121,7 @@ mod tests {
         assert_eq!(addr, addr_out);
     }
 
+    #[cfg(feature = "fil-actor")]
     #[test]
     fn test_ipc_serialization() {
         let sub_id = SubnetID::new(123, vec![Address::new_id(100)]);

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -8,10 +8,13 @@ pub enum Error {
     InvalidIPCAddr,
     #[error("fvm shared address error")]
     FVMAddressError(fvm_shared::address::Error),
+
+    #[cfg(feature = "fil-actor")]
     #[error("actor error")]
     Actor(fil_actors_runtime::ActorError),
 }
 
+#[cfg(feature = "fil-actor")]
 impl From<fil_actors_runtime::ActorError> for Error {
     fn from(e: fil_actors_runtime::ActorError) -> Self {
         Self::Actor(e)

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,4 +1,3 @@
-use fil_actors_runtime::fvm_ipld_hamt::BytesKey;
 use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::{address::Address, econ::TokenAmount};
@@ -12,7 +11,7 @@ pub mod subnet_id;
 /// as a key of a HAMT. This serialization has been
 /// tested to be compatible with its go counter-part
 /// in github.com/consensus-shipyard/go-ipc-types
-pub fn epoch_key(k: ChainEpoch) -> BytesKey {
+pub fn epoch_key(k: ChainEpoch) -> fvm_ipld_hamt::BytesKey {
     let bz = k.encode_var_vec();
     bz.into()
 }

--- a/sdk/src/subnet_id.rs
+++ b/sdk/src/subnet_id.rs
@@ -1,5 +1,3 @@
-use fil_actors_runtime::cbor;
-use fil_actors_runtime::runtime::Runtime;
 use fnv::FnvHasher;
 use fvm_shared::address::Address;
 use lazy_static::lazy_static;
@@ -10,7 +8,6 @@ use std::str::FromStr;
 
 use crate::error::Error;
 
-const SUBNET_ERR_TAG: &str = "subnetID";
 /// MaxChainID is the maximum chain ID value
 /// possible. This is the MAX_CHAIN_ID currently
 /// supported by Ethereum chains.
@@ -54,7 +51,8 @@ impl SubnetID {
     /// hosted in the current network. The rest of the route is left
     /// as-is. We only have information to translate from f2 to f0 for the
     /// last subnet actor in the root.
-    pub fn f0_id(&self, rt: &impl Runtime) -> SubnetID {
+    #[cfg(feature = "fil-actor")]
+    pub fn f0_id(&self, rt: &impl fil_actors_runtime::runtime::Runtime) -> SubnetID {
         let mut children = self.children();
 
         // replace the resolved child (if any)
@@ -107,8 +105,11 @@ impl SubnetID {
     }
 
     /// Returns the serialized version of the subnet id
+    #[cfg(feature = "fil-actor")]
     pub fn to_bytes(&self) -> Vec<u8> {
-        cbor::serialize(self, SUBNET_ERR_TAG).unwrap().into()
+        fil_actors_runtime::cbor::serialize(self, "subnetID")
+            .unwrap()
+            .into()
     }
 
     /// Returns the address of the actor governing the subnet in the parent


### PR DESCRIPTION
## Changes

- Adds a `fil-actor` feature so that we can depend on `ipc-sdk` _without_ having to add a dependency on the `fvm-utils/fil-actor-runtime` crate, which is a modified copy of the builtin-actors `Runtime`, which was generally not needed so far in a host application like Fendermint or the FVM.

## Tests

It still compiles, and disabling the feature only removes some methods that rely on the `Runtime`, which I do not intend to use. I added a step to the CI build to check the `ipc-sdk` with no default features, to catch any potential compilation bugs.

## Issues

Not at the moment.
