### PR TITLE
Migrate cross

### DIFF
--- a/atomic-exec/src/state.rs
+++ b/atomic-exec/src/state.rs
@@ -102,12 +102,12 @@ mod tests {
         let exec_id = AtomicExecID::from(Vec::from("exec_id"));
         let actors = vec![
             IPCAddress::new(
-                &SubnetID::new_from_parent(&*ROOTNET_ID, Address::new_id('A' as u64)),
+                &SubnetID::new_from_parent(&ROOTNET_ID, Address::new_id('A' as u64)),
                 &Address::new_id(1),
             )
             .unwrap(),
             IPCAddress::new(
-                &SubnetID::new_from_parent(&*ROOTNET_ID, Address::new_id('B' as u64)),
+                &SubnetID::new_from_parent(&ROOTNET_ID, Address::new_id('B' as u64)),
                 &Address::new_id(1),
             )
             .unwrap(),

--- a/gateway/src/checkpoint.rs
+++ b/gateway/src/checkpoint.rs
@@ -1,4 +1,4 @@
-use crate::{ensure_message_sorted, CrossMsg};
+use crate::ensure_message_sorted;
 use anyhow::anyhow;
 use cid::multihash::Code;
 use cid::multihash::MultihashDigest;
@@ -10,6 +10,7 @@ use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use ipc_actor_common::vote::{UniqueBytesKey, UniqueVote};
+use ipc_sdk::cross::CrossMsg;
 use ipc_sdk::subnet_id::SubnetID;
 use ipc_sdk::ValidatorSet;
 use lazy_static::lazy_static;

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -3,7 +3,6 @@
 extern crate core;
 
 pub use self::checkpoint::{BottomUpCheckpoint, CHECKPOINT_GENESIS_CID};
-pub use self::cross::{is_bottomup, CrossMsg, CrossMsgs, IPCMsgType, StorableMsg};
 pub use self::state::*;
 pub use self::subnet::*;
 pub use self::types::*;
@@ -22,6 +21,7 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::METHOD_SEND;
 use fvm_shared::{MethodNum, METHOD_CONSTRUCTOR};
 pub use ipc_sdk::address::IPCAddress;
+pub use ipc_sdk::cross::{CrossMsg, IPCMsgType, StorableMsg};
 pub use ipc_sdk::subnet_id::SubnetID;
 use ipc_sdk::ValidatorSet;
 use lazy_static::lazy_static;

--- a/gateway/src/state.rs
+++ b/gateway/src/state.rs
@@ -20,11 +20,11 @@ use std::str::FromStr;
 use crate::checkpoint::Validators;
 use crate::TopDownCheckpoint;
 use ipc_actor_common::vote::Voting;
+use ipc_sdk::cross::{CrossMsg, StorableMsg};
 use ipc_sdk::subnet_id::SubnetID;
 use ipc_sdk::ValidatorSet;
 
 use super::checkpoint::*;
-use super::cross::*;
 use super::subnet::*;
 use super::types::*;
 

--- a/gateway/src/subnet.rs
+++ b/gateway/src/subnet.rs
@@ -4,6 +4,7 @@ use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::repr::{Deserialize_repr, Serialize_repr};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
+use ipc_sdk::cross::CrossMsg;
 use primitives::{TAmt, TCid};
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
@@ -11,7 +12,6 @@ use crate::{State, CROSSMSG_AMT_BITWIDTH};
 use ipc_sdk::subnet_id::SubnetID;
 
 use super::checkpoint::*;
-use super::cross::CrossMsg;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize_repr, Serialize_repr)]
 #[repr(i32)]

--- a/gateway/src/types.rs
+++ b/gateway/src/types.rs
@@ -9,12 +9,11 @@ use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
 use fvm_shared::address::{Address, Protocol};
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
+use ipc_sdk::cross::CrossMsg;
 use ipc_sdk::subnet_id::SubnetID;
 use multihash::MultihashDigest;
 use primitives::CodeType;
 use std::cmp::Ordering;
-
-use crate::cross::CrossMsg;
 
 /// ID used in the builtin-actors bundle manifest
 pub const MANIFEST_ID: &str = "ipc_gateway";
@@ -118,7 +117,7 @@ pub(crate) fn resolved_from_to(
 
     // Check if they are equal to save ourselves a resolution
     if resolved {
-        if !equal_account_id(rt, &from_sig_addr, to) {
+        if !equal_account_id(rt, &from_sig_addr, to)? {
             from_sig_addr = resolve_secp_bls(rt, &from_sig_addr)?;
         } else {
             from_sig_addr = to_sig_addr;

--- a/gateway/src/types.rs
+++ b/gateway/src/types.rs
@@ -117,7 +117,7 @@ pub(crate) fn resolved_from_to(
 
     // Check if they are equal to save ourselves a resolution
     if resolved {
-        if !equal_account_id(rt, &from_sig_addr, to)? {
+        if !equal_account_id(rt, &from_sig_addr, to) {
             from_sig_addr = resolve_secp_bls(rt, &from_sig_addr)?;
         } else {
             from_sig_addr = to_sig_addr;

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -24,15 +24,15 @@ use fvm_shared::MethodNum;
 use fvm_shared::METHOD_SEND;
 use ipc_gateway::checkpoint::ChildCheck;
 use ipc_gateway::{
-    get_topdown_msg, Actor, AmountParams, BottomUpCheckpoint, ConstructorParams,
-    CrossMsg, CrossMsgParams, FundParams, IPCAddress, InitGenesisEpoch, Method, PropagateParams,
+    get_topdown_msg, Actor, AmountParams, BottomUpCheckpoint, ConstructorParams, CrossMsg,
+    CrossMsgParams, FundParams, IPCAddress, InitGenesisEpoch, Method, PropagateParams,
     ReleaseParams, State, StorableMsg, Subnet, SubnetID, TopDownCheckpoint, CROSS_MSG_FEE,
     DEFAULT_CHECKPOINT_PERIOD, MIN_COLLATERAL_AMOUNT, SUBNET_ACTOR_REWARD_METHOD,
 };
+use ipc_sdk::cross::is_bottomup;
 use ipc_sdk::ValidatorSet;
 use lazy_static::lazy_static;
 use primitives::{TCid, TCidContent};
-use ipc_sdk::cross::is_bottomup;
 
 lazy_static! {
     pub static ref SUBNET_ONE: Address = Address::new_id(101);

--- a/gateway/tests/harness.rs
+++ b/gateway/tests/harness.rs
@@ -24,7 +24,7 @@ use fvm_shared::MethodNum;
 use fvm_shared::METHOD_SEND;
 use ipc_gateway::checkpoint::ChildCheck;
 use ipc_gateway::{
-    get_topdown_msg, is_bottomup, Actor, AmountParams, BottomUpCheckpoint, ConstructorParams,
+    get_topdown_msg, Actor, AmountParams, BottomUpCheckpoint, ConstructorParams,
     CrossMsg, CrossMsgParams, FundParams, IPCAddress, InitGenesisEpoch, Method, PropagateParams,
     ReleaseParams, State, StorableMsg, Subnet, SubnetID, TopDownCheckpoint, CROSS_MSG_FEE,
     DEFAULT_CHECKPOINT_PERIOD, MIN_COLLATERAL_AMOUNT, SUBNET_ACTOR_REWARD_METHOD,
@@ -32,6 +32,7 @@ use ipc_gateway::{
 use ipc_sdk::ValidatorSet;
 use lazy_static::lazy_static;
 use primitives::{TCid, TCidContent};
+use ipc_sdk::cross::is_bottomup;
 
 lazy_static! {
     pub static ref SUBNET_ONE: Address = Address::new_id(101);

--- a/sdk/src/cross.rs
+++ b/sdk/src/cross.rs
@@ -1,0 +1,159 @@
+//! Cross network messages related struct and utility functions.
+
+use crate::address::IPCAddress;
+use crate::subnet_id::SubnetID;
+use anyhow::anyhow;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::MethodNum;
+use fvm_shared::METHOD_SEND;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+
+/// StorableMsg stores all the relevant information required
+/// to execute cross-messages.
+///
+/// We follow this approach because we can't directly store types.Message
+/// as we did in the actor's Go counter-part. Instead we just persist the
+/// information required to create the cross-messages and execute in the
+/// corresponding node implementation.
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct StorableMsg {
+    pub from: IPCAddress,
+    pub to: IPCAddress,
+    pub method: MethodNum,
+    pub params: RawBytes,
+    pub value: TokenAmount,
+    pub nonce: u64,
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct CrossMsg {
+    pub msg: StorableMsg,
+    pub wrapped: bool,
+}
+
+#[derive(PartialEq, Eq)]
+pub enum IPCMsgType {
+    BottomUp,
+    TopDown,
+}
+
+impl StorableMsg {
+    pub fn new_release_msg(
+        sub_id: &SubnetID,
+        from: &Address,
+        to: &Address,
+        value: TokenAmount,
+    ) -> anyhow::Result<Self> {
+        let to = IPCAddress::new(
+            &match sub_id.parent() {
+                Some(s) => s,
+                None => return Err(anyhow!("error getting parent for subnet addr")),
+            },
+            to,
+        )?;
+        let from = IPCAddress::new(sub_id, from)?;
+        Ok(Self {
+            from,
+            to,
+            method: METHOD_SEND,
+            params: RawBytes::default(),
+            value,
+            nonce: 0,
+        })
+    }
+
+    pub fn new_fund_msg(
+        sub_id: &SubnetID,
+        from: &Address,
+        to: &Address,
+        value: TokenAmount,
+    ) -> anyhow::Result<Self> {
+        let from = IPCAddress::new(
+            &match sub_id.parent() {
+                Some(s) => s,
+                None => return Err(anyhow!("error getting parent for subnet addr")),
+            },
+            from,
+        )?;
+        let to = IPCAddress::new(sub_id, to)?;
+        // the nonce and the rest of message fields are set when the message is committed.
+        Ok(Self {
+            from,
+            to,
+            method: METHOD_SEND,
+            params: RawBytes::default(),
+            value,
+            nonce: 0,
+        })
+    }
+
+    pub fn ipc_type(&self) -> anyhow::Result<IPCMsgType> {
+        let sto = self.to.subnet()?;
+        let sfrom = self.from.subnet()?;
+        if is_bottomup(&sfrom, &sto) {
+            return Ok(IPCMsgType::BottomUp);
+        }
+        Ok(IPCMsgType::TopDown)
+    }
+
+    pub fn apply_type(&self, curr: &SubnetID) -> anyhow::Result<IPCMsgType> {
+        let sto = self.to.subnet()?;
+        let sfrom = self.from.subnet()?;
+        if curr.common_parent(&sto) == sfrom.common_parent(&sto)
+            && self.ipc_type()? == IPCMsgType::BottomUp
+        {
+            return Ok(IPCMsgType::BottomUp);
+        }
+        Ok(IPCMsgType::TopDown)
+    }
+}
+
+pub fn is_bottomup(from: &SubnetID, to: &SubnetID) -> bool {
+    let index = match from.common_parent(to) {
+        Some((ind, _)) => ind,
+        None => return false,
+    };
+    // more children than the common parent
+    from.children_as_ref().len() > index
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Default, Serialize_tuple, Deserialize_tuple)]
+pub struct CrossMsgs {
+    // FIXME: Consider to make this an AMT if we expect
+    // a lot of cross-messages to be propagated.
+    pub msgs: Vec<CrossMsg>,
+}
+
+impl CrossMsgs {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cross::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_is_bottomup() {
+        bottom_up("/r123/f01", "/r123/f01/f02", false);
+        bottom_up("/r123/f01", "/r123", true);
+        bottom_up("/r123/f01", "/r123/f01/f02", false);
+        bottom_up("/r123/f01", "/r123/f02/f02", true);
+        bottom_up("/r123/f01/f02", "/r123/f01/f02", false);
+        bottom_up("/r123/f01/f02", "/r123/f01/f02/f03", false);
+    }
+
+    fn bottom_up(a: &str, b: &str, res: bool) {
+        assert_eq!(
+            is_bottomup(
+                &SubnetID::from_str(a).unwrap(),
+                &SubnetID::from_str(b).unwrap()
+            ),
+            res
+        );
+    }
+}

--- a/sdk/src/cross.rs
+++ b/sdk/src/cross.rs
@@ -126,9 +126,34 @@ pub struct CrossMsgs {
     pub msgs: Vec<CrossMsg>,
 }
 
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+struct ApplyMsgParams {
+    pub cross_msg: CrossMsg,
+}
+
 impl CrossMsgs {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+#[cfg(feature = "fil-actor")]
+impl CrossMsg {
+    pub fn send(self, rt: &mut impl fil_actors_runtime::runtime::Runtime, rto: &Address) -> Result<RawBytes, fil_actors_runtime::ActorError> {
+        let blk = if !self.wrapped {
+            let msg = self.msg;
+            rt.send(rto, msg.method, msg.params.into(), msg.value)?
+        } else {
+            let method = self.msg.method;
+            let value = self.msg.value.clone();
+            let params = fvm_ipld_encoding::ipld_block::IpldBlock::serialize_cbor(&ApplyMsgParams { cross_msg: self })?;
+            rt.send(rto, method, params, value)?
+        };
+
+        Ok(match blk {
+            Some(b) => b.data.into(), // FIXME: this assumes cbor serialization. We should maybe return serialized IpldBlock
+            None => RawBytes::default(),
+        })
     }
 }
 

--- a/sdk/src/cross.rs
+++ b/sdk/src/cross.rs
@@ -139,14 +139,21 @@ impl CrossMsgs {
 
 #[cfg(feature = "fil-actor")]
 impl CrossMsg {
-    pub fn send(self, rt: &mut impl fil_actors_runtime::runtime::Runtime, rto: &Address) -> Result<RawBytes, fil_actors_runtime::ActorError> {
+    pub fn send(
+        self,
+        rt: &mut impl fil_actors_runtime::runtime::Runtime,
+        rto: &Address,
+    ) -> Result<RawBytes, fil_actors_runtime::ActorError> {
         let blk = if !self.wrapped {
             let msg = self.msg;
             rt.send(rto, msg.method, msg.params.into(), msg.value)?
         } else {
             let method = self.msg.method;
             let value = self.msg.value.clone();
-            let params = fvm_ipld_encoding::ipld_block::IpldBlock::serialize_cbor(&ApplyMsgParams { cross_msg: self })?;
+            let params =
+                fvm_ipld_encoding::ipld_block::IpldBlock::serialize_cbor(&ApplyMsgParams {
+                    cross_msg: self,
+                })?;
             rt.send(rto, method, params, value)?
         };
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -4,6 +4,7 @@ use fvm_shared::{address::Address, econ::TokenAmount};
 use integer_encoding::VarInt;
 
 pub mod address;
+pub mod cross;
 pub mod error;
 pub mod subnet_id;
 


### PR DESCRIPTION
# Motivation
Cross network related types and utility functions will be used by not just `gateway` actor, but also `ipc-agent` and `fendermint`. Migrating to sdk helps `fendermint` and downstream crates from importing large chunks of irrelevant code in `gateway`.

# Solution
Just copy paste and update the dependency paths...