### PR TITLE
CHORE: Remove unused project dependency

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -24,7 +24,6 @@ integer-encoding = { version = "3.0.3", default-features = false }
 lazy_static = "1.4.0"
 log = "0.4.17"
 num-traits = "0.2.14"
-primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = "0.5"
 thiserror = "1.0.38"


### PR DESCRIPTION
The PR removes the `primitives` dependency from `ipc-sdk`. 

It turns out it wasn't used, by `primitives` has a reference to the `fil_actors_runtime` which I wanted to avoid having to drag in just to get access to `SubnetID` when I added the `fil-actors` feature in #128 