### PR TITLE
fix: remove stabilized feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           profile: minimal
           target: wasm32-unknown-unknown
-          toolchain: nightly-2022-10-03
+          toolchain: nightly
           override: true
       - run: cargo b --all
       - run: cargo t --all
@@ -51,7 +51,7 @@ jobs:
         with:
           profile: minimal
           target: wasm32-unknown-unknown
-          toolchain: nightly-2022-10-03
+          toolchain: nightly
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,1 @@
-#![feature(map_first_last)]
-
 pub mod vote;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-10-03"
-components = ["clippy", "llvm-tools-preview", "rustfmt"]
+channel = "nightly"
+components = ["clippy", "llvm-tools", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
* Update rust-toolchain and stabilize feature so the ipc-agent can compile seamlessly.

> NOTE: This PR is required to ensure that https://github.com/consensus-shipyard/ipc-agent/pull/301 compiles successfully. As part of https://github.com/consensus-shipyard/ipc-agent/issues/299 we are planning to migrate much of the common types to that repo and finally archive and deprecated the native actors until there's wasm support for the FVM. So I will defer fixing the CI/Tests till then, as there will be a lot more of work to be done when the time comes (and this way we don't have to work twice).